### PR TITLE
Prevent concurrent acceptance test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   acceptance:
     runs-on: ubuntu-latest
+    # Limit tests to 1 concurrent run because:
+    # - Datastreams are limited to 10 per customer
+    # - Apps can only be installed once per workspace
+    # When these limitations are removed, multiple acceptance tests runs can be execute concurrently.
+    concurrency:
+      group: tests
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Sets a concurrency group name so that only one acceptance test job will run at any given time. Concurrency groups in GitHub strictly function as a locking mechanism. There is no option to allow some specific number `n` concurrent jobs in a group. Our choices are 1 or infinite, so we can only drop this lock when there are no practical concurrency limitations on test runs.