### PR TITLE
Add sweeper workflow that runs nightly, on-demand, and on failed test runs

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -50,8 +50,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-      - name: Sweepers
-        timeout-minutes: 3
+      - timeout-minutes: 3
         run: make sweep
         env:
           # Environment variables for configuring the provider


### PR DESCRIPTION
Runs `make sweep`:

* When changing the workflow itself, or the sweeper file
* Every night
* On `workflow_dispatch`
* When the `test` workflow concludes with a failure on the acceptance job. 

By running in the same concurrency group, this should avoid clashing with acceptance test runs.

The last one is a new capability that we get via GitHub Actions. It should hopefully lead to more successful retries.

https://observe.atlassian.net/browse/OB-20747