### PR TITLE
release: remove `v` prefix from version in Boring Registry (S3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,10 @@ jobs:
     env:
       flags: ''
       tag: ${{ inputs.tag || github.ref_name }}
+    outputs:
+      version: ${{ steps.semver.outputs.version }}
     steps:
-      - name: Validate semver tag
+      - id: semver
         uses: matt-usurp/validate-semver@v1
         with:
           version: ${{ env.tag }}
@@ -84,7 +86,7 @@ jobs:
       id-token: write
     env:
       flags: ''
-      tag: ${{ inputs.tag || github.ref_name }}
+      version: ${{ needs.goreleaser.outputs.version }}
       upload_dir: ${{ github.workspace }}/upload
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
@@ -155,7 +157,7 @@ jobs:
       - name: Copy to S3
         run: |
           bucket="${{ vars.AWS_S3_REGISTRY_BUCKET }}"
-          prefix="${{ vars.AWS_S3_REGISTRY_PREFIX }}/version=${tag}/"
+          prefix="${{ vars.AWS_S3_REGISTRY_PREFIX }}/version=${version}/"
           s3_uri="s3://${bucket}/${prefix}"
 
           echo "::group::aws s3 cp"


### PR DESCRIPTION
Boring Registry expects bare semver versions, without the `v` prefix, in its `version=${version}` key segment.

https://github.com/observeinc/boring-registry#provider-registry-protocol

This workflow current includes git tag, which includes the prefix:

https://github.com/observeinc/terraform-provider-observe/actions/runs/5612625311#summary-15206981362

While I was busy scrutinizing the other path segments I totally overlooked this diff between existing releases and what the workflow planned in previous dry runs. This causes a client-side error when actually published:

```
╷
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider
│ terraform.observeinc.com/observeinc/observe: could not query provider registry for
│ terraform.observeinc.com/observeinc/observe: registry response includes invalid version string
│ "v0.13.14-rc1": a "v" prefix should not be used
```

The Terraform Registry requires tags with the `v` prefix and generally prefixing semver tags is advisable. So we need to switch but also parse the tag to get the version component, sans prefix.

The action we're already using to validate the semver tag parses it to do so and exposes the different properties as outputs. So I've exposed that from the `goreleaser` job so that the `release` job can use it.

In theory tag validation could be its own job that runs before `goreleaser` and then the `release` job could just use the output from that. But ultimately that just takes longer as it incurs overhead for job startup, even if it doesn't have to checkout the repo content. So I've deferred factoring that out until there's a more complex graph, with something running in parallel to `goreleaser`.