### PR TITLE
test: run `go test` with `-failfast`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           terraform_wrapper: false
       - name: Acceptance tests
         timeout-minutes: 25
-        run: make testacc
+        run: make testacc TESTARGS="-failfast"
         env:
           # Environment variables for configuring the provider
           OBSERVE_CUSTOMER: ${{ vars.OBSERVE_CUSTOMER }}


### PR DESCRIPTION
Run `go test` to exit as soon as one test fails. While this may mean the test you care about never runs, it's better than waiting for a whole suite after one flake:

Since all our acceptance tests are in one package `-failfast` should work:

https://github.com/golang/go/issues/33038