### PR TITLE
test: add workspace sweeper

### DIFF
--- a/observe/observe_sweeper_test.go
+++ b/observe/observe_sweeper_test.go
@@ -13,6 +13,20 @@ import (
 )
 
 func init() {
+	resource.AddTestSweepers("observe_workspace", &resource.Sweeper{
+		Name: "observe_workspace",
+		F:    workspaceSweeperFunc,
+		Dependencies: []string{
+			"observe_dataset",
+			"observe_monitor",
+			"observe_poller",
+			"observe_datastream",
+			"observe_folder",
+			"observe_preferred_path",
+			"observe_bookmark_group",
+			"observe_worksheet",
+		},
+	})
 	resource.AddTestSweepers("observe_dataset", &resource.Sweeper{
 		Name: "observe_dataset",
 		F:    datasetSweeperFunc,
@@ -96,6 +110,30 @@ func sharedClient(pattern string) (*client, error) {
 			return patternRe.MatchString(s)
 		},
 	}, nil
+}
+
+func workspaceSweeperFunc(pattern string) error {
+	client, err := sharedClient(pattern)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	workspaces, err := client.ListWorkspaces(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, workspace := range workspaces {
+		if client.MatchName(workspace.Label) {
+			log.Printf("[WARN] Deleting %s [id=%s]\n", workspace.Label, workspace.Id)
+			if err := client.DeleteWorkspace(ctx, workspace.Id); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func datasetSweeperFunc(pattern string) error {


### PR DESCRIPTION
Sweep workspaces created by the `observe_workspace` tests. Tested locally, prior to this we had a handful of leftovers.