### PR TITLE
test: increase timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: tests-${{ github.ref }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
       contents: read
@@ -26,7 +26,6 @@ jobs:
         with:
           terraform_wrapper: false
       - name: Acceptance tests
-        timeout-minutes: 25
         run: make testacc TESTARGS="-failfast"
         env:
           # Environment variables for configuring the provider


### PR DESCRIPTION
We are seeing long durations for `acceptance` jobs. 25m seemed reasonable but is causing more harm than good at this point. This more than doubles the relevant timeout.