### PR TITLE
fix(datastream): set workspace on read

### DIFF
--- a/observe/resource_datastream.go
+++ b/observe/resource_datastream.go
@@ -86,6 +86,10 @@ func newDatastreamConfig(data *schema.ResourceData) (*gql.DatastreamInput, diag.
 }
 
 func datastreamToResourceData(d *gql.Datastream, data *schema.ResourceData) (diags diag.Diagnostics) {
+	if err := data.Set("workspace", oid.WorkspaceOid(d.WorkspaceId).String()); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+
 	if err := data.Set("name", d.Name); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}


### PR DESCRIPTION
This sets the `workspace` attribute when refreshing a datastream. This is important for:

* Drift detection: if the workspace ID has changed on the server, Terraform should revert it back to the declared value
* Import: when a user imports a datastream, the provider needs to set the workspace ID in order for Terraform to detect whether the import matches or whether there's still drift to correct

Reported by @obs-gh-danielmartin 