### PR TITLE
chore(source_dataset): skip tests outside `CI`

### DIFF
--- a/observe/resource_source_dataset_test.go
+++ b/observe/resource_source_dataset_test.go
@@ -2,6 +2,7 @@ package observe
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 


### PR DESCRIPTION
When these tests run, they pass even when the underlying Snowflake operations fail. This is presumably a bug or design error with source datasets.

For now, skip the tests unless `CI=true`, since only in the account dedicated to CI testing for the provider are the schemas actually defined.

https://observeinc.slack.com/archives/CHV8QC3V0/p1690965832127859