### PR TITLE
chore(release): remove tag trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ on:
         type: string
         description: Previous Tag Name
         default: '' # GoReleaser will detect the previous tag if not specified
-  push:
-    tags:
-      - '*'
 
 jobs:
   goreleaser:


### PR DESCRIPTION
This eliminates the tag trigger for the release workflow in favor of always dispatching and assuming that the workflow will create the tag via the publication of the release.

GoReleaser is configured to publish a draft release. Normally, Github Actions won't trigger a recursive workflow. But in this case, the tag doesn't actually exist until someone clicks "Publish" on the draft release. And at that point, that user (e.g., me) is the actor, and not GHA. 

This ends up causing a duplicate workflow run:

https://github.com/observeinc/terraform-provider-observe/actions/runs/5787658452

It fails because of the artifact conflict and flips the release back to draft. 