### PR TITLE
chore: run app tests in parallel within workspaces

### DIFF
--- a/observe/data_source_app_test.go
+++ b/observe/data_source_app_test.go
@@ -11,20 +11,23 @@ import (
 func TestAccObserveDataApp(t *testing.T) {
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
-	// App tests must not be run in parallel because a given app (by module_id) can only be installed once per workspace
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(configPreamble+`
+				Config: fmt.Sprintf(`
+				resource "observe_workspace" "example" {
+					name = "%[1]s"
+				}
+
 				resource "observe_folder" "example" {
-				  workspace = data.observe_workspace.default.oid
+				  workspace = observe_workspace.example.oid
 				  name      = "%[1]s"
 				}
 
 				resource "observe_datastream" "example" {
-				  workspace = data.observe_workspace.default.oid
+				  workspace = observe_workspace.example.oid
 				  name      = "%[1]s"
 				}
 
@@ -52,14 +55,18 @@ func TestAccObserveDataApp(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(configPreamble+`
+				Config: fmt.Sprintf(`
+				resource "observe_workspace" "example" {
+					name = "%[1]s"
+				}
+
 				resource "observe_folder" "example" {
-				  workspace = data.observe_workspace.default.oid
+				  workspace = observe_workspace.example.oid
 				  name      = "%[1]s"
 				}
 
 				resource "observe_datastream" "example" {
-				  workspace = data.observe_workspace.default.oid
+				  workspace = observe_workspace.example.oid
 				  name      = "%[1]s"
 				}
 

--- a/observe/resource_app_test.go
+++ b/observe/resource_app_test.go
@@ -11,20 +11,23 @@ import (
 func TestAccObserveApp(t *testing.T) {
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
-	// App tests must not be run in parallel because a given app (by module_id) can only be installed once per workspace
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(configPreamble+`
+				Config: fmt.Sprintf(`
+				resource "observe_workspace" "example" {
+					name = "%[1]s"
+				}
+
 				resource "observe_folder" "example" {
-				  workspace = data.observe_workspace.default.oid
+				  workspace = observe_workspace.example.oid
 				  name      = "%[1]s"
 				}
 
 				resource "observe_datastream" "example" {
-				  workspace = data.observe_workspace.default.oid
+				  workspace = observe_workspace.example.oid
 				  name      = "%[1]s"
 				}
 


### PR DESCRIPTION
Wraps `observe_app`-dependent tests in an `observe_workspace`. Apps can only be installed once per workspace and so this becomes a cause of collisions and potentially requiring a sweeper run on errors. This should make the tests 100% side-effect free.

https://observe.atlassian.net/browse/OB-19271