### PR TITLE
restore `go test` timeout

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -94,7 +94,10 @@ testacc:
 		--junitfile test-report.xml \
 		--jsonfile test-output.json \
 		--rerun-fails=3 \
-		-- -parallel=5 $(TESTARGS)
+		-- \
+		-parallel=5 \
+		-timeout 30m \
+		$(TESTARGS)
 vet:
 	@echo "go vet ."
 	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \


### PR DESCRIPTION
Allows `go test` to run for 30 minutes. This got lost in #34. I realized we were seeing so many timeouts because we effectively reverted to the default `10m`!