### PR TITLE
layered_setting_record: fix `value_bool = false`

### DIFF
--- a/observe/resource_layered_setting_record.go
+++ b/observe/resource_layered_setting_record.go
@@ -283,7 +283,13 @@ func targetEncode(data *schema.ResourceData, target *gql.LayeredSettingRecordTar
 }
 
 func primitiveValueDecode(data *schema.ResourceData, ret *gql.PrimitiveValueInput) diag.Diagnostics {
-	valueBool, hasBool := data.GetOk("value_bool")
+	// value_bool must be read with GetOkExists because it is both optional and has no default
+	// GetOk returns !ok for the zero value of the type
+	// GetOkExists, which is deprecated, is the only way to handle this schema as declared
+	// Fixing this requires refactoring the schema (breaking). A more appropriate way to handle this API would be to have `type` and `value` fields, both strings.
+	// The `value` would be a JSON-encoded string of the appropriate type.
+	valueBool, hasBool := data.GetOkExists("value_bool")
+
 	//	NOTE: I rely on the fact that sizeof(int) == sizeof(int64) on modern systems
 	valueInt, hasInt := data.GetOk("value_int64")
 	valueFloat, hasFloat := data.GetOk("value_float64")

--- a/observe/resource_layered_setting_record_test.go
+++ b/observe/resource_layered_setting_record_test.go
@@ -16,30 +16,42 @@ func TestAccLayeredSettingRecord(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(configPreamble+datastreamConfigPreamble+`
-				resource "observe_layered_setting_record" "datasource" {
+				resource "observe_layered_setting_record" "datasource_int64" {
 					workspace   = data.observe_workspace.default.oid
-					name        = "%[1]s-dataset"
+					name        = "%[1]s-dataset-int64"
 					setting     = "Scanner.powerLevel"
 					value_int64 = 9009
 					target      = observe_datastream.test.dataset
 				}
 				
-				resource "observe_layered_setting_record" "datastream" {
+				resource "observe_layered_setting_record" "datastream_int64" {
 					workspace   = data.observe_workspace.default.oid
-					name        = "%[1]s-datastream"
+					name        = "%[1]s-datastream-int64"
 					setting     = "Scanner.powerLevel"
 					value_int64 = 9009
 					target      = observe_datastream.test.oid
 				}
+
+				resource "observe_layered_setting_record" "datasource_bool" {
+					workspace   = data.observe_workspace.default.oid
+					name        = "%[1]s-dataset-bool"
+					setting     = "Dataset.periodicReclusteringDisabled"
+					value_bool  = false
+					target      = observe_datastream.test.dataset
+				}
 				`, randomPrefix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource", "name", randomPrefix+"-dataset"),
-					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource", "value_int64", "9009"),
-					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource", "setting", "Scanner.powerLevel"),
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource_int64", "name", randomPrefix+"-dataset-int64"),
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource_int64", "value_int64", "9009"),
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource_int64", "setting", "Scanner.powerLevel"),
 
-					resource.TestCheckResourceAttr("observe_layered_setting_record.datastream", "name", randomPrefix+"-datastream"),
-					resource.TestCheckResourceAttr("observe_layered_setting_record.datastream", "value_int64", "9009"),
-					resource.TestCheckResourceAttr("observe_layered_setting_record.datastream", "setting", "Scanner.powerLevel"),
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datastream_int64", "name", randomPrefix+"-datastream-int64"),
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datastream_int64", "value_int64", "9009"),
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datastream_int64", "setting", "Scanner.powerLevel"),
+
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource_bool", "name", randomPrefix+"-dataset-bool"),
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource_bool", "value_bool", "false"),
+					resource.TestCheckResourceAttr("observe_layered_setting_record.datasource_bool", "setting", "Dataset.periodicReclusteringDisabled"),
 				),
 			},
 		},


### PR DESCRIPTION
As reported by @MatthiasObserve you cannot create a layered setting record with a `false` value. This fixes that and includes test coverage.

## Issue

```tf
resource "observe_layered_setting_record" "matthias_clustering_tests_scale_0001_sorting_LS_autoclustering" {
  workspace  = data.observe_workspace.default.oid
  setting    = "Dataset.automaticClusteringEnabled"
  target     = observe_dataset.foo.oid
  value_bool = false
}
```

```
Error: A value must be specified (value_string, value_bool, etc)
```

## Cause

The cause of this is incorrect usage of [`GetOk`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.GetOk):

> GetOk returns the data for the given key and **whether or not the key has been set to a non-zero value** at some point.

## Hacky Solution

[`GetOkExists`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.GetOkExists) is a deprecated method designed for this purpose:

> GetOkExists can check if TypeBool attributes that are Optional with no Default value have been set. Deprecated: usage is discouraged due to undefined behaviors and may be removed in a future version of the SDK

## Permanent Solution

Having `value_${type}` fields is not a viable design pattern in Terraform, for the reasons described above. At least not on their own. A `type` field should be defined and then optionally the `value_*` fields can be collapsed into a single `value` string field. This eliminates the need to detect whether fields are set, which is not supported outside of the deprecated `GetOkExists` method. Either:

```tf
resource "observe_layered_setting" "typed" {
  type       = "bool"
  value_bool = false
}
```

Or:

```tf
resource "observe_layered_setting" "string" {
  type  = "bool"
  value = false
}
```

Terraform should implicitly cast `false` to `"false"` but it may need to be explicitly quoted. Then the provider can just `switch` on the `type` field's value and parse the `value` to the appropriate type (or read `value_*`). 

The latter is closer to a breaking change but we could do this in two stages:

1. Add `type` and `value` (exclusive with all `value_*`) and deprecate all `value_*` (non-breaking)
2. Remove `value_*` and make `type` and `value` required (breaking)

After 2 we can drop the deprecated method use.

https://observe.atlassian.net/browse/OB-22384