### PR TITLE
filedrop: fix nil disabled attribute

### DIFF
--- a/client/internal/meta/operation/filedrop.graphql
+++ b/client/internal/meta/operation/filedrop.graphql
@@ -33,6 +33,7 @@ query getFiledrop($id: ObjectId!) {
     }
 }
 
+# @genqlient(for: "FiledropInput.disabled", omitempty: true)
 mutation createFiledrop(
     $workspaceID: ObjectId!,
     $datastreamID: ObjectId!,
@@ -44,7 +45,11 @@ mutation createFiledrop(
     }
 }
 
-mutation updateFiledrop($id: ObjectId!, $input: FiledropInput!) {
+# @genqlient(for: "FiledropInput.disabled", omitempty: true)
+mutation updateFiledrop(
+    $id: ObjectId!,
+    $input: FiledropInput!
+) {
     # @genqlient(pointer: true, flatten: true)
     filedrop: updateFiledrop(id: $id, input: $input) {
         ...Filedrop

--- a/client/internal/meta/schema/filedrop.graphql
+++ b/client/internal/meta/schema/filedrop.graphql
@@ -14,6 +14,13 @@ interface FiledropEndpoint @goModel(model: "observe/meta/metatypes.FiledropEndpo
     type: FiledropEndpointType!
 }
 
+extend type Mutation {
+    """
+    Enable or disable an existing filedrop
+    """
+    setFiledropDisabled(id: ObjectId!, disabled: Boolean!): ResultStatus!
+}
+
 extend type Query {
     filedrop(id: ObjectId!): Filedrop!
     searchFiledrop(workspaceId: ObjectId, folderId: ObjectId, nameExact: String, nameSubstring: String): FiledropSearchResult!
@@ -26,24 +33,24 @@ extend type Mutation {
 }
 
 enum FiledropEndpointType @goModel(model: "observe/meta/metatypes.FiledropEndpointType") {
-    S3
+  S3
 }
 
 enum FiledropFormatType @goModel(model: "observe/meta/metatypes.FiledropFormatType") {
-    Csv
-    Json
-    Parquet
+  Csv
+  Json
+  Parquet
 }
 
 enum FiledropProviderType @goModel(model: "observe/meta/metatypes.FiledropProviderType") {
-    Aws
+  Aws
 }
 
 enum FiledropStatus @goModel(model: "observe/meta/metatypes.FiledropStatus") {
-    Disabled
-    Initializing
-    Running
-    Updating
+  Disabled
+  Initializing
+  Running
+  Updating
 }
 
 type Filedrop implements WorkspaceObject & AuditedObject & FolderObject @goModel(model: "observe/meta/metatypes.Filedrop") {
@@ -52,6 +59,7 @@ type Filedrop implements WorkspaceObject & AuditedObject & FolderObject @goModel
     status of the filedrop
     """
     status: FiledropStatus!
+    disabled: Boolean
     """
     ID of the datastream associated with the filedrop
     """
@@ -63,6 +71,7 @@ type Filedrop implements WorkspaceObject & AuditedObject & FolderObject @goModel
     config: FiledropConfig!
     endpoint: FiledropEndpoint!
     # tramp data: metadata: FiledropMetadata!
+    stats: DatastreamTokenStats @goField(forceResolver: true)
     # WorkspaceObject
     id: ObjectId!
     workspaceId: ObjectId!
@@ -87,11 +96,13 @@ type Filedrop implements WorkspaceObject & AuditedObject & FolderObject @goModel
 input FiledropInput @goModel(model: "observe/meta/metatypes.FiledropInput") {
     # payload
     # not in input: status: FiledropStatus!
-    # immutable: datastreamID: Int64!
+    disabled: Boolean
+    # immutable: datastreamID: ObjectId!
     # not in input: datastreamTokenID: String!
     config: FiledropConfigInput!
     # not in input: endpoint: FiledropEndpoint!
     # tramp field: metadata: FiledropMetadataInput!
+    # resolver: stats: DatastreamTokenStats
     # WorkspaceObject
     name: String
     iconUrl: String
@@ -166,4 +177,18 @@ type FiledropS3Endpoint implements FiledropEndpoint @goModel(model: "observe/met
     """
     prefix: String!
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -2356,6 +2356,7 @@ const (
 )
 
 type FiledropInput struct {
+	Disabled    *bool               `json:"disabled,omitempty"`
 	Config      FiledropConfigInput `json:"config"`
 	Name        *string             `json:"name"`
 	IconUrl     *string             `json:"iconUrl"`
@@ -2363,6 +2364,9 @@ type FiledropInput struct {
 	ManagedById *string             `json:"managedById"`
 	FolderId    *string             `json:"folderId"`
 }
+
+// GetDisabled returns FiledropInput.Disabled, and is useful for accessing the field via an interface.
+func (v *FiledropInput) GetDisabled() *bool { return v.Disabled }
 
 // GetConfig returns FiledropInput.Config, and is useful for accessing the field via an interface.
 func (v *FiledropInput) GetConfig() FiledropConfigInput { return v.Config }


### PR DESCRIPTION
Fixes a break in `observe_filedrop`.

## Problem

Tests are currently erroring because `observe_filedrop` is broken:

https://github.com/observeinc/terraform-provider-observe/actions/runs/6028881306/job/16361706619?pr=51#step:6:451

```
input: filedrop.input.disabled <nil> is not a bool
```

## Fix

* Update the schema, just for filedrop because of other breaking changes (see #51)
* Add a directive so that `disabled` is omitted if empty, which it will always be

In the future this attribute should be implemented in the provider.