### PR TITLE
fix: remove format from filedrop

### DIFF
--- a/client/internal/meta/operation/filedrop.graphql
+++ b/client/internal/meta/operation/filedrop.graphql
@@ -7,9 +7,6 @@ fragment Filedrop on Filedrop {
     status
     datastreamID
     config {
-        format {
-            type
-        }
         provider {
             ... on FiledropProviderAwsConfig {
                 region

--- a/client/internal/meta/schema/filedrop.graphql
+++ b/client/internal/meta/schema/filedrop.graphql
@@ -119,14 +119,14 @@ type FiledropSearchResult @goModel(model: "observe/meta/metatypes.FiledropSearch
 # User provided configuration that defines a filedrop
 type FiledropConfig @goModel(model: "observe/meta/metatypes.FiledropConfig") {
     # payload
-    format: FiledropFormatConfig!
+    format: FiledropFormatConfig
     provider: FiledropProviderConfig!
     # not in output: providerAws: FiledropProviderAwsConfig
 }
 
 input FiledropConfigInput @goModel(model: "observe/meta/metatypes.FiledropConfigInput") {
     # payload
-    format: FiledropFormatConfigInput!
+    format: FiledropFormatConfigInput
     # not in input: provider: FiledropProviderConfig!
     providerAws: FiledropProviderAwsConfigInput
 }

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -2156,12 +2156,8 @@ func (v *Filedrop) __premarshalJSON() (*__premarshalFiledrop, error) {
 
 // FiledropConfig includes the requested fields of the GraphQL type FiledropConfig.
 type FiledropConfig struct {
-	Format   FiledropConfigFormatFiledropFormatConfig     `json:"format"`
 	Provider FiledropConfigProviderFiledropProviderConfig `json:"-"`
 }
-
-// GetFormat returns FiledropConfig.Format, and is useful for accessing the field via an interface.
-func (v *FiledropConfig) GetFormat() FiledropConfigFormatFiledropFormatConfig { return v.Format }
 
 // GetProvider returns FiledropConfig.Provider, and is useful for accessing the field via an interface.
 func (v *FiledropConfig) GetProvider() FiledropConfigProviderFiledropProviderConfig {
@@ -2202,8 +2198,6 @@ func (v *FiledropConfig) UnmarshalJSON(b []byte) error {
 }
 
 type __premarshalFiledropConfig struct {
-	Format FiledropConfigFormatFiledropFormatConfig `json:"format"`
-
 	Provider json.RawMessage `json:"provider"`
 }
 
@@ -2218,7 +2212,6 @@ func (v *FiledropConfig) MarshalJSON() ([]byte, error) {
 func (v *FiledropConfig) __premarshalJSON() (*__premarshalFiledropConfig, error) {
 	var retval __premarshalFiledropConfig
 
-	retval.Format = v.Format
 	{
 
 		dst := &retval.Provider
@@ -2234,21 +2227,13 @@ func (v *FiledropConfig) __premarshalJSON() (*__premarshalFiledropConfig, error)
 	return &retval, nil
 }
 
-// FiledropConfigFormatFiledropFormatConfig includes the requested fields of the GraphQL type FiledropFormatConfig.
-type FiledropConfigFormatFiledropFormatConfig struct {
-	Type FiledropFormatType `json:"type"`
-}
-
-// GetType returns FiledropConfigFormatFiledropFormatConfig.Type, and is useful for accessing the field via an interface.
-func (v *FiledropConfigFormatFiledropFormatConfig) GetType() FiledropFormatType { return v.Type }
-
 type FiledropConfigInput struct {
-	Format      FiledropFormatConfigInput       `json:"format"`
+	Format      *FiledropFormatConfigInput      `json:"format"`
 	ProviderAws *FiledropProviderAwsConfigInput `json:"providerAws"`
 }
 
 // GetFormat returns FiledropConfigInput.Format, and is useful for accessing the field via an interface.
-func (v *FiledropConfigInput) GetFormat() FiledropFormatConfigInput { return v.Format }
+func (v *FiledropConfigInput) GetFormat() *FiledropFormatConfigInput { return v.Format }
 
 // GetProviderAws returns FiledropConfigInput.ProviderAws, and is useful for accessing the field via an interface.
 func (v *FiledropConfigInput) GetProviderAws() *FiledropProviderAwsConfigInput { return v.ProviderAws }
@@ -9698,9 +9683,6 @@ fragment Filedrop on Filedrop {
 	status
 	datastreamID
 	config {
-		format {
-			type
-		}
 		provider {
 			__typename
 			... on FiledropProviderAwsConfig {
@@ -12278,9 +12260,6 @@ fragment Filedrop on Filedrop {
 	status
 	datastreamID
 	config {
-		format {
-			type
-		}
 		provider {
 			__typename
 			... on FiledropProviderAwsConfig {
@@ -14764,9 +14743,6 @@ fragment Filedrop on Filedrop {
 	status
 	datastreamID
 	config {
-		format {
-			type
-		}
 		provider {
 			__typename
 			... on FiledropProviderAwsConfig {

--- a/docs/resources/filedrop.md
+++ b/docs/resources/filedrop.md
@@ -38,17 +38,7 @@ should be used when referring to this object in terraform manifests.
 
 Required:
 
-- `format` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--config--format))
 - `provider` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--config--provider))
-
-<a id="nestedblock--config--format"></a>
-### Nested Schema for `config.format`
-
-Required:
-
-- `type` (String) The file format of the file that you will be dropping.
- Accepted values: parquet, csv, json
-
 
 <a id="nestedblock--config--provider"></a>
 ### Nested Schema for `config.provider`

--- a/observe/resource_filedrop.go
+++ b/observe/resource_filedrop.go
@@ -73,21 +73,6 @@ func resourceFiledrop() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"format": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"type": {
-										Type:             schema.TypeString,
-										Required:         true,
-										Description:      describeEnums(gql.AllFiledropFormatTypes, descriptions.Get("filedrop", "schema", "config", "format", "type")),
-										ValidateDiagFunc: validateEnums(gql.AllFiledropFormatTypes),
-									},
-								},
-							},
-						},
 						"provider": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -175,14 +160,10 @@ func newFiledropConfig(data *schema.ResourceData) (input *gql.FiledropInput, dia
 }
 
 func expandFiledropConfig(data map[string]interface{}) gql.FiledropConfigInput {
-	format := data["format"].([]interface{})[0].(map[string]interface{})
 	provider := data["provider"].([]interface{})[0].(map[string]interface{})
 	aws := provider["aws"].([]interface{})[0].(map[string]interface{})
 
 	config := gql.FiledropConfigInput{
-		Format: gql.FiledropFormatConfigInput{
-			Type: gql.FiledropFormatType(toCamel(format["type"].(string))),
-		},
 		ProviderAws: &gql.FiledropProviderAwsConfigInput{
 			Region:  aws["region"].(string),
 			RoleArn: aws["role_arn"].(string),
@@ -321,12 +302,7 @@ func resourceFiledropRead(ctx context.Context, data *schema.ResourceData, meta i
 }
 
 func flattenFiledropConfig(config gql.FiledropConfig) interface{} {
-	format := map[string]interface{}{
-		"type": toSnake(string(config.Format.Type)),
-	}
-	data := map[string]interface{}{
-		"format": []interface{}{format},
-	}
+	data := map[string]interface{}{}
 
 	if awsConfig, ok := config.Provider.(*gql.FiledropConfigProviderFiledropProviderAwsConfig); ok {
 		aws := map[string]interface{}{

--- a/observe/resource_filedrop_test.go
+++ b/observe/resource_filedrop_test.go
@@ -28,9 +28,6 @@ func TestAccObserveFiledrop(t *testing.T) {
 					workspace  = data.observe_workspace.default.oid
 					datastream = observe_datastream.test.oid
 					config {
-						format {
-							type = "json"
-						}
 						provider {
 							aws {
 								region  = "us-west-2"
@@ -42,7 +39,6 @@ func TestAccObserveFiledrop(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("observe_filedrop.example", "name"),
 					resource.TestCheckResourceAttrSet("observe_filedrop.example", "status"),
-					resource.TestCheckResourceAttr("observe_filedrop.example", "config.0.format.0.type", "json"),
 					resource.TestCheckResourceAttr("observe_filedrop.example", "config.0.provider.0.aws.0.region", "us-west-2"),
 					resource.TestCheckResourceAttr("observe_filedrop.example", "config.0.provider.0.aws.0.role_arn", filedropRoleArn),
 					resource.TestCheckResourceAttrSet("observe_filedrop.example", "endpoint.0.s3.0.arn"),
@@ -57,9 +53,6 @@ func TestAccObserveFiledrop(t *testing.T) {
 					name       = "%[1]s"
 					datastream = observe_datastream.test.oid
 					config {
-						format {
-							type = "json"
-						}
 						provider {
 							aws {
 								region  = "us-west-2"
@@ -71,7 +64,6 @@ func TestAccObserveFiledrop(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("observe_filedrop.example", "name", randomPrefix),
 					resource.TestCheckResourceAttrSet("observe_filedrop.example", "status"),
-					resource.TestCheckResourceAttr("observe_filedrop.example", "config.0.format.0.type", "json"),
 					resource.TestCheckResourceAttr("observe_filedrop.example", "config.0.provider.0.aws.0.region", "us-west-2"),
 					resource.TestCheckResourceAttr("observe_filedrop.example", "config.0.provider.0.aws.0.role_arn", filedropRoleArn),
 					resource.TestCheckResourceAttrSet("observe_filedrop.example", "endpoint.0.s3.0.arn"),


### PR DESCRIPTION
Format has been deprecated from the filedrop API. We can remove the field outright since we filedrop is not yet GA.