### PR TITLE
dependabot: add secrets

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -15,7 +15,7 @@ resource "github_actions_secret" "secrets" {
 resource "github_dependabot_secret" "secrets" {
   for_each = {
     # Automatically expose any OBSERVE_* credentials as Dependabot secrets to allow aceptance testing PRs
-    k, v in github_actions_secret.secrets : k => v if startswith(k, "OBSERVE")
+    for k, v in github_actions_secret.secrets : k => v if startswith(k, "OBSERVE")
   }
 
   repository      = each.value.repository


### PR DESCRIPTION
Adds all secrets as Dependabot secrets in addition to Actions ones so acceptance tests can run on Dependabot PRs:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions