### PR TITLE
dependabot: add config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    open-pull-requests-limit: 1
+    schedule:
+      interval: weekly
+      day: monday
+      # Times are staggered by 30m to spread load
+      time: '02:00'
+      timezone: US/Pacific
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 1
+    schedule:
+      interval: weekly
+      day: monday
+      time: '02:30'
+      timezone: US/Pacific
+  - package-ecosystem: terraform
+    directory: /
+    open-pull-requests-limit: 1
+    schedule:
+      interval: weekly
+      day: monday
+      time: '03:00'
+      timezone: US/Pacific


### PR DESCRIPTION
Enables automated dependency updates via Dependabot. The initial configuration is conservative, enabling only 1 concurrent PR per package ecosystem, via 1 weekly check. There's no way to share concurrency (or schedule settings) across all ecosystems.

GitHub Actions and Terraform should mostly be up to date as those are recent. The Go dependencies in `go.mod` will in many cases be heavily out of date. We can make individual PRs to update dependencies in chunks or in bulk using Go tooling. But otherwise this will steadily advance us 1 dependency at a time.

https://observe.atlassian.net/browse/OB-22155