### PR TITLE
go: upgrade to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observeinc/terraform-provider-observe
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Khan/genqlient v0.6.0


### PR DESCRIPTION
Upgrades from Go 1.18 to 1.20. Workflows use `go.mod` to decide which version to build on:

https://github.com/observeinc/terraform-provider-observe/blob/8f041b64d8cfcc129850a2092abde4636a98cf3b/.github/workflows/test.yml#L22-L24

Dependencies will start requiring this if they make use of new functionality, such as in #77 where a new provider SDK version is using `errors.Join`. 