### PR TITLE
docs: make provider schema gen deterministic

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,10 @@ import (
 	"github.com/observeinc/terraform-provider-observe/observe"
 )
 
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate
+//go:generate env -u OBSERVE_CUSTOMER go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate
+// `env -u` unsets a variable.  This prevents the go generate command from inheriting it.
+// When set, `OBSERVE_CUSTOMER` defines the default for the `customer` provider attribute.
+// This makes this required field optional, since a default is set.
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{

--- a/observe/provider.go
+++ b/observe/provider.go
@@ -24,9 +24,14 @@ func Provider() *schema.Provider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"customer": {
-				Type:        schema.TypeString,
+				Type: schema.TypeString,
+
+				// Since this field is required but uses an EnvDefaultFunc,
+				// documentation should be generated with `env -u OBSERVE_CUSTOMER`
+				// to ensure the default is unset.
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OBSERVE_CUSTOMER", nil),
+
 				Description: "Your Observe Customer ID.",
 			},
 			"api_token": {


### PR DESCRIPTION
Fixes a seemingly non-deterministic issue with provider docs generation, which caused the `customer` attribute to move from _Required_ to _Optional_.

## Background

We’ve observed that running go generate produces different results:

https://github.com/observeinc/terraform-provider-observe/blob/master/docs/index.md#schema

Sometimes customer, the one required attribute, is rendered in the Optional section. There's a GitHub Actions workflow that runs go generate && git diff and fails. The user must then revert this (incorrect) change.

So we need to identify the source of this non-determinism.

## Analysis

I was able to identify the root cause via rubber ducking with Konstantin. He mentioned that trying a different terminal produced the expected result and that he’d set `OBSERVE_*` credentials in the first one. Then it clicked for me.

`tfplugindocs` works by using the terraform providers schema command to get a JSON representation of the provider’s schema:

https://developer.hashicorp.com/terraform/cli/commands/providers/schema#block-representation 

Notably nowhere in this serialized schema is a `Default`. And that’s done because defaults can be computed at runtime. This is used to allow providers to read defaults from environment variables.

https://github.com/observeinc/terraform-provider-observe/blob/0f5a10671114380b289d3fae68b17fc1313bbdd2/observe/provider.go#L29

And so it turns out that Terraform will return `optional: true` for that attribute.

> if set to true, specifies that an omitted or null value is permitted.

In that sense, the attribute is optional, since an omitted (at least from the configuration) value is permitted.

## Solution

Using `env -u` unsets the relevant environment variable. I'd prefer `--unset` but that's not portable to macOS's version of `env`. We could use a script to discover all `OBSERVE_*` variables and construct unset arguments, but this would be more than a one-liner. We cannot use `env -i` (prevents all env inheritance) because that breaks things like `PATH` which can prevents `go` and `terraform` from being found. 

I also left a comment alongside the attribute itself in hopes that when someone refactors this to `url` or similar instead of `customer` and `domain` they'll notice that similar treatment is needed for their new environment variable.

## Related

https://observe.atlassian.net/browse/OB-26565