### PR TITLE
OB-28708: Serialize GetDataset with write-operations

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -25,6 +25,11 @@ var (
 
 // GetDataset returns dataset by ID
 func (c *Client) GetDataset(ctx context.Context, id string) (*meta.Dataset, error) {
+	if !c.Flags[flagObs2110] {
+		c.obs2110.Lock()
+		defer c.obs2110.Unlock()
+	}
+
 	return c.Meta.GetDataset(ctx, id)
 }
 


### PR DESCRIPTION
Hello,

Right now when we install a large app there's a race inside APIServer which is caused by concurrent writes (causing cache purges) and reads created by TF provider.
Simple workaround is to serialize reads.