### PR TITLE
Fix wrongly calculated monitor reminder settings

### DIFF
--- a/observe/resource_monitor.go
+++ b/observe/resource_monitor.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	observe "github.com/observeinc/terraform-provider-observe/client"
 	gql "github.com/observeinc/terraform-provider-observe/client/meta"
 	"github.com/observeinc/terraform-provider-observe/client/meta/types"
@@ -953,12 +952,12 @@ func flattenNotificationSpec(spec gql.MonitorNotificationSpecNotificationSpecifi
 		"importance": toSnake(string(spec.Importance)),
 	}
 
-	if spec.ReminderFrequency != 0 {
-		result["reminder_frequency"] = spec.ReminderFrequency.String()
-	}
-
 	if spec.NotifyOnReminder != nil {
 		result["notify_on_reminder"] = *spec.NotifyOnReminder
+
+		if *spec.NotifyOnReminder && spec.ReminderFrequency != 0 {
+			result["reminder_frequency"] = spec.ReminderFrequency.String()
+		}
 	}
 
 	if spec.NotifyOnClose != nil {

--- a/observe/resource_monitor_test.go
+++ b/observe/resource_monitor_test.go
@@ -256,6 +256,43 @@ func TestAccObserveMonitorThreshold(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_monitor.first", "notification_spec.0.importance", "informational"),
 					resource.TestCheckResourceAttr("observe_monitor.first", "notification_spec.0.merge", "merged"),
 					resource.TestCheckResourceAttr("observe_monitor.first", "disabled", "false"),
+					resource.TestCheckResourceAttr("observe_monitor.first", "notification_spec.0.notify_on_reminder", "true"),
+					resource.TestCheckResourceAttr("observe_monitor.first", "notification_spec.0.reminder_frequency", "5m0s"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(monitorConfigPreamble+`
+				resource "observe_monitor" "first" {
+					workspace = data.observe_workspace.default.oid
+					name      = "%[1]s"
+
+					inputs = {
+						"test" = observe_datastream.test.dataset
+					}
+
+					stage {
+						pipeline = "colmake temp_number:14"
+					}
+
+
+					rule {
+                        source_column    = "temp_number"
+
+						threshold {
+                            compare_function = "greater"
+                            compare_values   = [ 70 ]
+                            lookback_time    = "10m0s"
+						}
+					}
+
+					notification_spec {
+						merge = "merged"
+						notify_on_close = true
+					}
+				}`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor.first", "notification_spec.0.notify_on_reminder", "false"),
+					resource.TestCheckResourceAttr("observe_monitor.first", "notification_spec.0.reminder_frequency", ""),
 				),
 			},
 		},


### PR DESCRIPTION
GQL API and TF resource spec don't exactly match. GQL expects both notifyOnReminder and reminderFrequency. Within TF we treat notify_on_reminder as a computed attribute if reminder_frequency is not empty (nil).

GQL API returns non-empty reminder_frequency even if notify_on_reminder is empty. Therefore extra check is needed.