### PR TITLE
feat: add observe_ingest_info

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -1337,3 +1337,7 @@ func (c *Client) DeleteCorrelationTag(ctx context.Context, dataset, tag string, 
 	}
 	return c.Meta.DeleteCorrelationTag(ctx, dataset, tag, path)
 }
+
+func (c *Client) GetIngestInfo(ctx context.Context) (*meta.IngestInfo, error) {
+	return c.Meta.GetIngestInfo(ctx)
+}

--- a/client/internal/meta/operation/ingest.graphql
+++ b/client/internal/meta/operation/ingest.graphql
@@ -1,0 +1,15 @@
+fragment IngestInfo on IngestInfo {
+    collectUrl
+    domain
+    scheme
+    port
+}
+
+query getIngestInfo() {
+	ingest: currentCustomer {
+            # @genqlient(flatten: true)
+            ingestInfo {
+                ...IngestInfo
+            }
+    }
+}

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -2632,6 +2632,30 @@ func (v *HttpRequestConfig) GetHeaders() *types.JsonObject { return v.Headers }
 // GetParams returns HttpRequestConfig.Params, and is useful for accessing the field via an interface.
 func (v *HttpRequestConfig) GetParams() *types.JsonObject { return v.Params }
 
+// IngestInfo includes the GraphQL fields of IngestInfo requested by the fragment IngestInfo.
+// The GraphQL type's documentation follows.
+//
+// Information on the data ingestion endpoint, full URL format is:
+// <scheme>://<customerId>.collect.<domain>:<port>/
+type IngestInfo struct {
+	CollectUrl string `json:"collectUrl"`
+	Domain     string `json:"domain"`
+	Scheme     string `json:"scheme"`
+	Port       string `json:"port"`
+}
+
+// GetCollectUrl returns IngestInfo.CollectUrl, and is useful for accessing the field via an interface.
+func (v *IngestInfo) GetCollectUrl() string { return v.CollectUrl }
+
+// GetDomain returns IngestInfo.Domain, and is useful for accessing the field via an interface.
+func (v *IngestInfo) GetDomain() string { return v.Domain }
+
+// GetScheme returns IngestInfo.Scheme, and is useful for accessing the field via an interface.
+func (v *IngestInfo) GetScheme() string { return v.Scheme }
+
+// GetPort returns IngestInfo.Port, and is useful for accessing the field via an interface.
+func (v *IngestInfo) GetPort() string { return v.Port }
+
 type InputDefinitionInput struct {
 	// Assign the short and unique user mnemonic for this input, used in @tableref expressions
 	InputName string `json:"inputName"`
@@ -9107,6 +9131,22 @@ type getFolderResponse struct {
 // GetFolder returns getFolderResponse.Folder, and is useful for accessing the field via an interface.
 func (v *getFolderResponse) GetFolder() Folder { return v.Folder }
 
+// getIngestInfoIngestCustomer includes the requested fields of the GraphQL type Customer.
+type getIngestInfoIngestCustomer struct {
+	IngestInfo IngestInfo `json:"ingestInfo"`
+}
+
+// GetIngestInfo returns getIngestInfoIngestCustomer.IngestInfo, and is useful for accessing the field via an interface.
+func (v *getIngestInfoIngestCustomer) GetIngestInfo() IngestInfo { return v.IngestInfo }
+
+// getIngestInfoResponse is returned by getIngestInfo on success.
+type getIngestInfoResponse struct {
+	Ingest *getIngestInfoIngestCustomer `json:"ingest"`
+}
+
+// GetIngest returns getIngestInfoResponse.Ingest, and is useful for accessing the field via an interface.
+func (v *getIngestInfoResponse) GetIngest() *getIngestInfoIngestCustomer { return v.Ingest }
+
 // getLayeredSettingRecordResponse is returned by getLayeredSettingRecord on success.
 type getLayeredSettingRecordResponse struct {
 	LayeredSettingRecord LayeredSettingRecord `json:"layeredSettingRecord"`
@@ -13676,6 +13716,45 @@ func getFolder(
 	var err error
 
 	var data getFolderResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by getIngestInfo.
+const getIngestInfo_Operation = `
+query getIngestInfo {
+	ingest: currentCustomer {
+		ingestInfo {
+			... IngestInfo
+		}
+	}
+}
+fragment IngestInfo on IngestInfo {
+	collectUrl
+	domain
+	scheme
+	port
+}
+`
+
+func getIngestInfo(
+	ctx context.Context,
+	client graphql.Client,
+) (*getIngestInfoResponse, error) {
+	req := &graphql.Request{
+		OpName: "getIngestInfo",
+		Query:  getIngestInfo_Operation,
+	}
+	var err error
+
+	var data getIngestInfoResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/client/meta/ingest.go
+++ b/client/meta/ingest.go
@@ -1,0 +1,13 @@
+package meta
+
+import "context"
+
+func (client *Client) GetIngestInfo(ctx context.Context) (*IngestInfo, error) {
+	resp, err := getIngestInfo(ctx, client.Gql)
+	if err != nil {
+		return nil, err
+	}
+
+	info := resp.GetIngest().GetIngestInfo()
+	return &info, nil
+}

--- a/observe/data_source_ingest_info.go
+++ b/observe/data_source_ingest_info.go
@@ -1,0 +1,71 @@
+package observe
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	observe "github.com/observeinc/terraform-provider-observe/client"
+	gql "github.com/observeinc/terraform-provider-observe/client/meta"
+	"github.com/observeinc/terraform-provider-observe/observe/descriptions"
+)
+
+func dataSourceIngestInfo() *schema.Resource {
+	return &schema.Resource{
+		Description: descriptions.Get("ingest_info", "description"),
+		ReadContext: dataSourceIngestInfoRead,
+		Schema: map[string]*schema.Schema{
+			// computed values
+			"collect_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("ingest_info", "schema", "collect_url"),
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("ingest_info", "schema", "domain"),
+			},
+			"scheme": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("ingest_info", "schema", "scheme"),
+			},
+			"port": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("ingest_info", "schema", "port"),
+			},
+		},
+	}
+}
+
+func dataSourceIngestInfoRead(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
+	var (
+		client = meta.(*observe.Client)
+	)
+
+	info, err := client.GetIngestInfo(ctx)
+	if err != nil {
+		diags = diag.FromErr(err)
+		return
+	}
+	return ingestInfoToResourceData(info, data)
+}
+
+func ingestInfoToResourceData(info *gql.IngestInfo, data *schema.ResourceData) (diags diag.Diagnostics) {
+	if err := data.Set("collect_url", info.CollectUrl); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := data.Set("scheme", info.Scheme); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := data.Set("domain", info.Domain); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	if err := data.Set("port", info.Port); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+	data.SetId(info.CollectUrl)
+	return diags
+}

--- a/observe/data_source_ingest_info_test.go
+++ b/observe/data_source_ingest_info_test.go
@@ -1,0 +1,25 @@
+package observe
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccObserveIngestInfo(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				data "observe_ingest_info" "current" {}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.observe_ingest_info.current", "collect_url"),
+					resource.TestCheckResourceAttrSet("data.observe_ingest_info.current", "domain"),
+				),
+			},
+		},
+	})
+}

--- a/observe/descriptions/ingest_info.yaml
+++ b/observe/descriptions/ingest_info.yaml
@@ -1,0 +1,11 @@
+description:
+  Ingest info for the Observe tenant.
+schema:
+  collect_url: |
+    Base URL for the Observe ingest API.
+  domain: |
+    Base domain for the Observe ingest API.
+  scheme: |
+    URI scheme for ingesting data.
+  port: |
+    Port over which data should be sent. If omitted, assume scheme defaults.

--- a/observe/provider.go
+++ b/observe/provider.go
@@ -137,6 +137,7 @@ func Provider() *schema.Provider {
 			"observe_oid":               dataSourceOID(),
 			"observe_rbac_group":        dataSourceRbacGroup(),
 			"observe_user":              dataSourceUser(),
+			"observe_ingest_info":       dataSourceIngestInfo(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"observe_dataset":                   resourceDataset(),


### PR DESCRIPTION
This data source is useful when attempting to generate instructions for submitting data to the current Observe tenant.