### PR TITLE
fix: filter EOL fields from schema

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,6 +68,8 @@ copy-gql-schema:
 	[ -d "$(OBSERVE_ROOT)" ]
 	rm -f client/internal/meta/schema/*.graphql
 	cp -pR "$(OBSERVE_ROOT)/code/go/src/observe/meta/metagql/schema/"*.graphql client/internal/meta/schema/
+	sed -i.bak '/@eol/ { /directive/!d; }' client/internal/meta/schema/*
+	rm -rf client/internal/meta/schema/*.bak
 
 generate:
 	go generate ./...

--- a/client/internal/meta/operation/dataset.graphql
+++ b/client/internal/meta/operation/dataset.graphql
@@ -7,7 +7,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	version
-	lastSaved
+	updatedDate
 	pathCost
 	source
 	managedById

--- a/client/internal/meta/operation/poller.graphql
+++ b/client/internal/meta/operation/poller.graphql
@@ -102,7 +102,6 @@ fragment Poller on Poller {
 	}
 }
 
-# @genqlient(for: "PollerInput.cloudwatchMetricsConfig", omitempty: true)
 mutation createPoller(
     $workspaceId: ObjectId!,
     $poller: PollerInput!,
@@ -120,7 +119,6 @@ query getPoller($id: ObjectId!) {
 	}
 }
 
-# @genqlient(for: "PollerInput.cloudwatchMetricsConfig", omitempty: true)
 mutation updatePoller(
     $id: ObjectId!,
     $poller: PollerInput!,

--- a/client/internal/meta/schema/base.graphql
+++ b/client/internal/meta/schema/base.graphql
@@ -20,6 +20,11 @@ directive @goModel(model: String, models: [String!]) on OBJECT
 directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION
     | FIELD_DEFINITION
 
+directive @eol on
+    | INPUT_FIELD_DEFINITION
+    | FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+
 scalar Any @goModel(model: "observe/meta/metascalar.Any")
 scalar CustomerId @goModel(model: "observe/authorization/id.CustomerId")
 scalar Duration @goModel(model: "observe/compiler/comptypes.Duration")

--- a/client/internal/meta/schema/dataset.graphql
+++ b/client/internal/meta/schema/dataset.graphql
@@ -32,7 +32,12 @@ extend type Mutation {
     If dependencyHandling is not specified, then the default is to apply
     changes but ignore downstream datasets or errors therein.
     """
-    saveDataset(workspaceId: ObjectId!, dataset: DatasetInput!, transform: TransformInput @deprecated(reason:"use query instead"), query: MultiStageQueryInput, dependencyHandling: DependencyHandlingInput): DatasetSaveResult
+    saveDataset(
+        workspaceId: ObjectId!,
+        dataset: DatasetInput!,
+        query: MultiStageQueryInput,
+        dependencyHandling: DependencyHandlingInput,
+    ): DatasetSaveResult
     deleteDataset(dsid: ObjectId!, dependencyHandling: DependencyHandlingInput): ResultStatus
 
     saveSourceDataset(workspaceId: ObjectId!, datasetDefinition: DatasetDefinitionInput!, sourceTable: SourceTableDefinitionInput!, dependencyHandling: DependencyHandlingInput): DatasetSaveResult
@@ -331,7 +336,6 @@ type Dataset implements WorkspaceObject & FolderObject & AuditedObject & Acceler
     correlationTagMappings: [CorrelationTagMapping!] @goField(forceResolver:false)
     latestPublished: Time @deprecated(reason: "use version instead") @goField(name:version)
     versions: [Time!] @goField(forceResolver:true)
-    lastSaved: Time! @deprecated(reason: "use updatedDate instead")
     isSourceDataset: Boolean
     transform: Transform @goField(forceResolver:true)
     inputs: [DatasetInputDataset!] @goField(forceResolver:true)

--- a/client/internal/meta/schema/poller.graphql
+++ b/client/internal/meta/schema/poller.graphql
@@ -274,7 +274,6 @@ input PollerInput @goModel(model: "observe/meta/metatypes.PollerInput") {
     mongoDBAtlasConfig: PollerMongoDBAtlasInput
     confluentCloudConfig: PollerConfluentCloudInput
     cloudWatchMetricsConfig: PollerCloudWatchMetricsInput
-    cloudwatchMetricsConfig: PollerCloudWatchMetricsInput @deprecated(reason:"renamed to cloudWatchMetricsConfig")
     awsSnapshotConfig: PollerAWSSnapshotInput
     skipExternalValidation: Boolean
 

--- a/client/meta/dataset.go
+++ b/client/meta/dataset.go
@@ -75,7 +75,7 @@ func (client *Client) SaveSourceDataset(ctx context.Context, workspaceId string,
 }
 
 func (d *Dataset) Oid() *oid.OID {
-	version := d.LastSaved.String()
+	version := d.UpdatedDate.String()
 	return &oid.OID{
 		Id:      d.Id,
 		Type:    oid.TypeDataset,

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -1260,7 +1260,7 @@ type Dataset struct {
 	IconUrl              *string            `json:"iconUrl"`
 	AccelerationDisabled bool               `json:"accelerationDisabled"`
 	Version              types.TimeScalar   `json:"version"`
-	LastSaved            types.TimeScalar   `json:"lastSaved"`
+	UpdatedDate          types.TimeScalar   `json:"updatedDate"`
 	PathCost             *types.Int64Scalar `json:"pathCost"`
 	Source               *string            `json:"source"`
 	ManagedById          *string            `json:"managedById"`
@@ -1297,8 +1297,8 @@ func (v *Dataset) GetAccelerationDisabled() bool { return v.AccelerationDisabled
 // GetVersion returns Dataset.Version, and is useful for accessing the field via an interface.
 func (v *Dataset) GetVersion() types.TimeScalar { return v.Version }
 
-// GetLastSaved returns Dataset.LastSaved, and is useful for accessing the field via an interface.
-func (v *Dataset) GetLastSaved() types.TimeScalar { return v.LastSaved }
+// GetUpdatedDate returns Dataset.UpdatedDate, and is useful for accessing the field via an interface.
+func (v *Dataset) GetUpdatedDate() types.TimeScalar { return v.UpdatedDate }
 
 // GetPathCost returns Dataset.PathCost, and is useful for accessing the field via an interface.
 func (v *Dataset) GetPathCost() *types.Int64Scalar { return v.PathCost }
@@ -6553,7 +6553,6 @@ type PollerInput struct {
 	MongoDBAtlasConfig      *PollerMongoDBAtlasInput      `json:"mongoDBAtlasConfig"`
 	ConfluentCloudConfig    *PollerConfluentCloudInput    `json:"confluentCloudConfig"`
 	CloudWatchMetricsConfig *PollerCloudWatchMetricsInput `json:"cloudWatchMetricsConfig"`
-	CloudwatchMetricsConfig *PollerCloudWatchMetricsInput `json:"cloudwatchMetricsConfig,omitempty"`
 	AwsSnapshotConfig       *PollerAWSSnapshotInput       `json:"awsSnapshotConfig"`
 	SkipExternalValidation  *bool                         `json:"skipExternalValidation"`
 	// The optional id of the object that owns the poller. Ex: The id of an AppDataSource instance.
@@ -6607,11 +6606,6 @@ func (v *PollerInput) GetConfluentCloudConfig() *PollerConfluentCloudInput {
 // GetCloudWatchMetricsConfig returns PollerInput.CloudWatchMetricsConfig, and is useful for accessing the field via an interface.
 func (v *PollerInput) GetCloudWatchMetricsConfig() *PollerCloudWatchMetricsInput {
 	return v.CloudWatchMetricsConfig
-}
-
-// GetCloudwatchMetricsConfig returns PollerInput.CloudwatchMetricsConfig, and is useful for accessing the field via an interface.
-func (v *PollerInput) GetCloudwatchMetricsConfig() *PollerCloudWatchMetricsInput {
-	return v.CloudwatchMetricsConfig
 }
 
 // GetAwsSnapshotConfig returns PollerInput.AwsSnapshotConfig, and is useful for accessing the field via an interface.
@@ -15112,7 +15106,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	version
-	lastSaved
+	updatedDate
 	pathCost
 	source
 	managedById
@@ -16891,7 +16885,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	version
-	lastSaved
+	updatedDate
 	pathCost
 	source
 	managedById
@@ -17091,7 +17085,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	version
-	lastSaved
+	updatedDate
 	pathCost
 	source
 	managedById
@@ -17902,7 +17896,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	version
-	lastSaved
+	updatedDate
 	pathCost
 	source
 	managedById
@@ -18021,7 +18015,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	version
-	lastSaved
+	updatedDate
 	pathCost
 	source
 	managedById


### PR DESCRIPTION
This commit filters deprecated fields, as marked by the @eol directive, from the client schema, adjusting the provider code as we go.