### PR TITLE
Fix a bug in correlation tag resource

### DIFF
--- a/observe/resource_correlation_tag.go
+++ b/observe/resource_correlation_tag.go
@@ -101,13 +101,20 @@ func resourceCorrelationTagCreate(ctx context.Context, data *schema.ResourceData
 		return diags
 	}
 
-	err := client.CreateCorrelationTag(ctx, params.Dataset, params.Tag, params.Path)
+	isPresent, err := client.IsCorrelationTagPresent(ctx, params.Dataset, params.Tag, params.Path)
 	if err != nil {
-		return append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "failed to create correlation tag",
-			Detail:   err.Error(),
-		})
+		return diag.FromErr(err)
+	}
+
+	if !isPresent {
+		err := client.CreateCorrelationTag(ctx, params.Dataset, params.Tag, params.Path)
+		if err != nil {
+			return append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "failed to create correlation tag",
+				Detail:   err.Error(),
+			})
+		}
 	}
 
 	data.SetId(constructCorrelationTagId(params.Dataset, params.Tag, params.Path))


### PR DESCRIPTION
We currently run into the following problem with correlation tags:

1. Say a user created a correlation tag manually in UI
2. If an app is later changed to add the same correlation tag to the dataset, the app can no longer be installed on the customer's environment because of the conflict in correlation tag.

To fix this problem, I'm changing the provider to look at existing tags as part of the creation.

There is one pending task in this PR:
1. How do I test this in our tests?