### PR TITLE
fix: UserAgent in release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X version.ProviderVersion={{.Version}}'
+    - '-s -w -X github.com/observeinc/terraform-provider-observe/version.ProviderVersion={{.Version}}'
   goos:
     - windows
     - linux


### PR DESCRIPTION
Something has changed in the Go linker and/or the repository, and we must now specify the fully qualified symbol to have it properly overwrite it with the release tag.