### PR TITLE
Fix: support importing monitor_v2 and monitor_v2_action resources

### DIFF
--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -481,3 +481,8 @@ Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
 
+## Import
+Import is supported using the following syntax:
+```shell
+terraform import observe_monitor_v2.example 1414010
+```

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -480,7 +480,6 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
-
 ## Import
 Import is supported using the following syntax:
 ```shell

--- a/docs/resources/monitor_v2_action.md
+++ b/docs/resources/monitor_v2_action.md
@@ -66,3 +66,9 @@ Required:
 - `header` (String)
 - `value` (String)
 
+## Import
+Import is supported using the following syntax:
+```shell
+terraform import observe_monitor_v2_action.example 1414010
+```
+

--- a/docs/resources/monitor_v2_action.md
+++ b/docs/resources/monitor_v2_action.md
@@ -65,10 +65,8 @@ Required:
 
 - `header` (String)
 - `value` (String)
-
 ## Import
 Import is supported using the following syntax:
 ```shell
 terraform import observe_monitor_v2_action.example 1414010
 ```
-

--- a/examples/resources/observe_monitor_v2/import.sh
+++ b/examples/resources/observe_monitor_v2/import.sh
@@ -1,0 +1,1 @@
+terraform import observe_monitor_v2.example 1414010

--- a/examples/resources/observe_monitor_v2_action/import.sh
+++ b/examples/resources/observe_monitor_v2_action/import.sh
@@ -1,0 +1,1 @@
+terraform import observe_monitor_v2_action.example 1414010

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -23,6 +23,9 @@ func resourceMonitorV2() *schema.Resource {
 		ReadContext:   resourceMonitorV2Read,
 		UpdateContext: resourceMonitorV2Update,
 		DeleteContext: resourceMonitorV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			// needed as input to MonitorV2Create, also part of MonitorV2 struct
 			"workspace": { // ObjectId!

--- a/observe/resource_monitor_v2_action.go
+++ b/observe/resource_monitor_v2_action.go
@@ -19,6 +19,9 @@ func resourceMonitorV2Action() *schema.Resource {
 		ReadContext:   resourceMonitorV2ActionRead,
 		UpdateContext: resourceMonitorV2ActionUpdate,
 		DeleteContext: resourceMonitorV2ActionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			// needed as input to CreateMonitorV2Action
 			"workspace": { // ObjectId!


### PR DESCRIPTION
Trying to run `terraform import` for a monitor_v2 resource resulted in the following error:
```
Error: resource observe_monitor_v2 doesn't support import
```
Turns out the `Importer` function needs to be implemented, and in this case I believe we can just use `ImportStatePassthroughContext` based on my understanding of the [docs](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/import)