### PR TITLE
Update Terraform state for NOT_FOUND (1/n)

### DIFF
--- a/client/meta/helpers.go
+++ b/client/meta/helpers.go
@@ -153,6 +153,10 @@ var AllMonitorV2HttpTypes = []MonitorV2HttpType{
 	MonitorV2HttpTypePut,
 }
 
+const (
+	ErrNotFound = "NOT_FOUND"
+)
+
 type resultStatusResponse interface {
 	GetResultStatus() ResultStatus
 }

--- a/observe/resource_dataset_outbound_share.go
+++ b/observe/resource_dataset_outbound_share.go
@@ -194,6 +194,10 @@ func resourceDatasetOutboundShareRead(ctx context.Context, d *schema.ResourceDat
 
 	datasetShare, err := client.GetDatasetOutboundShare(ctx, d.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Failed to read dataset outbound share",

--- a/observe/resource_datastream.go
+++ b/observe/resource_datastream.go
@@ -142,6 +142,10 @@ func resourceDatastreamRead(ctx context.Context, data *schema.ResourceData, meta
 	client := meta.(*observe.Client)
 	result, err := client.GetDatastream(ctx, data.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			data.SetId("")
+			return nil
+		}
 		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  fmt.Sprintf("failed to retrieve datastream [id=%s]", data.Id()),

--- a/observe/resource_filedrop.go
+++ b/observe/resource_filedrop.go
@@ -259,6 +259,10 @@ func resourceFiledropRead(ctx context.Context, data *schema.ResourceData, meta i
 
 	filedrop, err := client.GetFiledrop(ctx, data.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			data.SetId("")
+			return nil
+		}
 		return diag.Errorf("failed to read filedrop: %s", err.Error())
 	}
 

--- a/observe/resource_monitor.go
+++ b/observe/resource_monitor.go
@@ -775,6 +775,10 @@ func resourceMonitorRead(ctx context.Context, data *schema.ResourceData, meta in
 
 	monitor, err := client.GetMonitor(ctx, data.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			data.SetId("")
+			return nil
+		}
 		return diag.Errorf("failed to read monitor: %s", err.Error())
 	}
 

--- a/observe/resource_monitor_action.go
+++ b/observe/resource_monitor_action.go
@@ -269,6 +269,10 @@ func resourceMonitorActionRead(ctx context.Context, data *schema.ResourceData, m
 
 	monitorActionPtr, err := client.GetMonitorAction(ctx, data.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			data.SetId("")
+			return nil
+		}
 		return diag.Errorf("failed to read monitor action: %s", err.Error())
 	}
 	monitorAction := *monitorActionPtr

--- a/observe/resource_monitor_action_attachment.go
+++ b/observe/resource_monitor_action_attachment.go
@@ -139,7 +139,7 @@ func resourceMonitorActionAttachmentRead(ctx context.Context, data *schema.Resou
 
 	monitorActionAttachmentPtr, err := client.GetMonitorActionAttachment(ctx, data.Id())
 	if err != nil {
-		if gql.HasErrorCode(err, "NOT_FOUND") {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
 			data.SetId("")
 			return nil
 		}

--- a/observe/resource_rbac_group.go
+++ b/observe/resource_rbac_group.go
@@ -92,6 +92,10 @@ func resourceRbacGroupRead(ctx context.Context, data *schema.ResourceData, meta 
 
 	group, err := client.GetRbacGroup(ctx, data.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			data.SetId("")
+			return nil
+		}
 		return diag.Errorf("failed to read rbacgroup: %s", err.Error())
 	}
 	return rbacGroupToResourceData(group, data)

--- a/observe/resource_rbac_group_member.go
+++ b/observe/resource_rbac_group_member.go
@@ -127,6 +127,10 @@ func resourceRbacGroupmemberRead(ctx context.Context, data *schema.ResourceData,
 
 	group, err := client.GetRbacGroupmember(ctx, data.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			data.SetId("")
+			return nil
+		}
 		return diag.Errorf("failed to read rbacgroupmember: %s", err.Error())
 	}
 	return rbacGroupmemberToResourceData(group, data)

--- a/observe/resource_rbac_statement.go
+++ b/observe/resource_rbac_statement.go
@@ -245,6 +245,10 @@ func resourceRbacStatementRead(ctx context.Context, data *schema.ResourceData, m
 
 	stmt, err := client.GetRbacStatement(ctx, data.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			data.SetId("")
+			return nil
+		}
 		return diag.Errorf("failed to read rbacstatement: %s", err.Error())
 	}
 	return rbacStatementToResourceData(stmt, data)

--- a/observe/resource_snowflake_outbound_share.go
+++ b/observe/resource_snowflake_outbound_share.go
@@ -128,6 +128,10 @@ func resourceSnowflakeOutboundShareRead(ctx context.Context, d *schema.ResourceD
 
 	share, err := client.GetSnowflakeOutboundShare(ctx, d.Id())
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
Updated the following resources to properly handle NOT_FOUND responses from the upstream:
- `dataset_outbound_share`
- `datastream`
- `filedrop`
- `monitor`
- `monitor_action`
- `rbac_group`
- `rbac_group_member`
- `rbac_statement`
- `snowflake_outbound_share`