### PR TITLE
fix: bug with encoding path for groupings

### DIFF
--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -1020,7 +1020,7 @@ func newMonitorV2CountRuleInput(path string, data *schema.ResourceData) (compari
 	// optionals
 	if _, ok := data.GetOk(fmt.Sprintf("%scompare_groups", path)); ok {
 		compareGroups := make([]gql.MonitorV2ColumnComparisonInput, 0)
-		for _, i := range data.Get(fmt.Sprintf("%scompare_groups", path)).([]interface{}) {
+		for i := range data.Get(fmt.Sprintf("%scompare_groups", path)).([]interface{}) {
 			columnComparison, diags := newMonitorV2ColumnComparisonInput(fmt.Sprintf("%scompare_groups.%d.", path, i), data)
 			if diags.HasError() {
 				return nil, diags

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -881,7 +881,7 @@ func newMonitorV2DefinitionInput(data *schema.ResourceData) (defnInput *gql.Moni
 	}
 	if _, ok := data.GetOk("groupings"); ok {
 		groupings := make([]gql.MonitorV2ColumnInput, 0)
-		for _, i := range data.Get("groupings").([]interface{}) {
+		for i := range data.Get("groupings").([]interface{}) {
 			colInput, diags := newMonitorV2ColumnInput(fmt.Sprintf("groupings.%d.", i), data)
 			if diags.HasError() {
 				return nil, diags


### PR DESCRIPTION
Small typo that resulted in putting the data in the `path` instead of the index