### PR TITLE
feat: support dataTableViewState field for datasets

### DIFF
--- a/client/internal/meta/operation/dataset.graphql
+++ b/client/internal/meta/operation/dataset.graphql
@@ -12,6 +12,7 @@ fragment Dataset on Dataset {
 	source
 	managedById
 	onDemandMaterializationLength
+	dataTableViewState
 	foreignKeys {
 		label
 		targetDataset

--- a/client/internal/meta/schema/dataset.graphql
+++ b/client/internal/meta/schema/dataset.graphql
@@ -184,12 +184,26 @@ type DatasetSaveResult @goModel(model: "observe/meta/metaparser.DatasetSaveResul
     """
     errorDatasets: [DatasetError!]
     """
-    True when saving the dataset results in throwing away materialized data.
+    Changing a dataset definition might make currently materialized data obsolete,
+    in which case we dematerialize (throw away) this data and recompute new data.
+    This is the list of datasets that would get dematerialized.
+
     Data is dematerialized when the change to the dataset is significant,
     that is, when it alters transform logic. Minor changes like whitespace and
     comments do not cause dematerialization.
+
+    Note that changing a dataset might cause downstream datasets to get
+    dematerialized also.
     """
     dematerializedDatasets: [DatasetMaterialization!]
+    """
+    The Observe compute credit (OCC) cost of rematerializing affected datasets.
+    Note that the datasets in this list might differ from those in dematerializedDatasets
+    since this list might include some upstream datasets. In general, don't try
+    to correlate elements in this list with elements in other lists; treat them
+    independently as much as possible.
+    """
+    rematerializationCosts: [DatasetCostEstimate!]
 }
 
 """Information about a materialized dataset."""
@@ -350,6 +364,7 @@ type Dataset implements WorkspaceObject & FolderObject & AuditedObject & Acceler
     managedById: ObjectId
     folderId: ObjectId!
     indexMetadata: IndexMetadata @deprecated(reason: "use fieldList.indexDefs instead")
+    dataTableViewState: JsonObject
 
     """
     Optional custom configured override value of the on demand materialization
@@ -362,24 +377,17 @@ type Dataset implements WorkspaceObject & FolderObject & AuditedObject & Acceler
 
     # AccelerableObject (or fields that should eventually move to that interface)
     accelerable: Boolean!
-    streamable: Boolean! @deprecated(reason: "renamed to accelerable") @goField(name:accelerable)
     accelerationInfo: AccelerationInfo! @goField(forceResolver:true)
     accelerationDisabled: Boolean! @goField(name:materializationDisabled)
 
     """
-    True if this dataset is hibernated. In this case, the dataset will not
-    automatically accelerate new data. You can still query the dataset on the
-    accelerated range and issue manual acceleration jobs.
-    """
-    hibernated: Boolean!
-
-    """
+    If the dataset is not hibernated, this field will be set to null.
     If the dataset is hibernated, this field will be set to the time when it was
     hibernated. The dataset will not automatically accelerate new data.
     You can still query the dataset on the accelerated range and issue manual
     acceleration jobs.
     """
-    hibernatedAt: Time
+    hibernatedAt: Time @goField(forceResolver:true)
 
     # AuditedObject
     createdBy: UserId!
@@ -391,13 +399,13 @@ type Dataset implements WorkspaceObject & FolderObject & AuditedObject & Acceler
 }
 
 enum MetricType @goModel(model: "observe/compiler/comptypes.MetricType") {
-    CumulativeCounter
-    Counter @deprecated(reason: "This field is no longer supported in set_metric verb.")
-    RatePerSec @deprecated(reason: "This field is no longer supported in set_metric verb.")
-    Delta
-    Gauge
-    Tdigest
-    Sample
+    cumulativeCounter
+    counter @deprecated(reason: "This field is no longer supported in set_metric verb.")
+    ratePerSec @deprecated(reason: "This field is no longer supported in set_metric verb.")
+    delta
+    gauge
+    tdigest
+    sample
 }
 
 type MetricTag @goModel(model: "observe/compiler/comptypes.MetricTag") {
@@ -589,6 +597,7 @@ input DatasetInput @goModel(model: "observe/meta/metatypes.DatasetInput") {
     iconUrl: String
     layout: JsonObject
     pathCost: Int64
+    dataTableViewState: JsonObject
     """
     Max on-demand materialization length for the dataset (in nanoseconds). If not set
     will use the default value in transformer config.

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -1251,6 +1251,7 @@ type Dataset struct {
 	// Optional custom configured override value of the on demand materialization
 	// range for the dataset.
 	OnDemandMaterializationLength *types.Int64Scalar                       `json:"onDemandMaterializationLength"`
+	DataTableViewState            *types.JsonObject                        `json:"dataTableViewState"`
 	ForeignKeys                   []DatasetForeignKeysForeignKey           `json:"foreignKeys"`
 	Transform                     *DatasetTransform                        `json:"transform"`
 	Typedef                       DatasetTypedef                           `json:"typedef"`
@@ -1297,6 +1298,9 @@ func (v *Dataset) GetManagedById() *string { return v.ManagedById }
 func (v *Dataset) GetOnDemandMaterializationLength() *types.Int64Scalar {
 	return v.OnDemandMaterializationLength
 }
+
+// GetDataTableViewState returns Dataset.DataTableViewState, and is useful for accessing the field via an interface.
+func (v *Dataset) GetDataTableViewState() *types.JsonObject { return v.DataTableViewState }
 
 // GetForeignKeys returns Dataset.ForeignKeys, and is useful for accessing the field via an interface.
 func (v *Dataset) GetForeignKeys() []DatasetForeignKeysForeignKey { return v.ForeignKeys }
@@ -1434,6 +1438,7 @@ type DatasetInput struct {
 	IconUrl              *string            `json:"iconUrl"`
 	Layout               *types.JsonObject  `json:"layout"`
 	PathCost             *types.Int64Scalar `json:"pathCost"`
+	DataTableViewState   *types.JsonObject  `json:"dataTableViewState"`
 	// Max on-demand materialization length for the dataset (in nanoseconds). If not set
 	// will use the default value in transformer config.
 	OnDemandMaterializationLength *types.Int64Scalar `json:"onDemandMaterializationLength"`
@@ -1476,6 +1481,9 @@ func (v *DatasetInput) GetLayout() *types.JsonObject { return v.Layout }
 
 // GetPathCost returns DatasetInput.PathCost, and is useful for accessing the field via an interface.
 func (v *DatasetInput) GetPathCost() *types.Int64Scalar { return v.PathCost }
+
+// GetDataTableViewState returns DatasetInput.DataTableViewState, and is useful for accessing the field via an interface.
+func (v *DatasetInput) GetDataTableViewState() *types.JsonObject { return v.DataTableViewState }
 
 // GetOnDemandMaterializationLength returns DatasetInput.OnDemandMaterializationLength, and is useful for accessing the field via an interface.
 func (v *DatasetInput) GetOnDemandMaterializationLength() *types.Int64Scalar {
@@ -15188,6 +15196,7 @@ fragment Dataset on Dataset {
 	source
 	managedById
 	onDemandMaterializationLength
+	dataTableViewState
 	foreignKeys {
 		label
 		targetDataset
@@ -16955,6 +16964,7 @@ fragment Dataset on Dataset {
 	source
 	managedById
 	onDemandMaterializationLength
+	dataTableViewState
 	foreignKeys {
 		label
 		targetDataset
@@ -17155,6 +17165,7 @@ fragment Dataset on Dataset {
 	source
 	managedById
 	onDemandMaterializationLength
+	dataTableViewState
 	foreignKeys {
 		label
 		targetDataset
@@ -17974,6 +17985,7 @@ fragment Dataset on Dataset {
 	source
 	managedById
 	onDemandMaterializationLength
+	dataTableViewState
 	foreignKeys {
 		label
 		targetDataset
@@ -18284,6 +18296,7 @@ fragment Dataset on Dataset {
 	source
 	managedById
 	onDemandMaterializationLength
+	dataTableViewState
 	foreignKeys {
 		label
 		targetDataset

--- a/docs/data-sources/dataset.md
+++ b/docs/data-sources/dataset.md
@@ -37,6 +37,7 @@ One of `name` or `id` must be set. If `name` is provided, `workspace` must be se
 ### Read-Only
 
 - `acceleration_disabled` (Boolean)
+- `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI
 - `description` (String) Dataset description.
 - `freshness` (String) Target freshness for results. Tighten the freshness to increase the
 frequency with which queries are run, which incurs higher transform costs.

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -50,6 +50,7 @@ its predecessor. (see [below for nested schema](#nestedblock--stage))
 ### Optional
 
 - `acceleration_disabled` (Boolean) Disables periodic materialization of the dataset
+- `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI
 - `description` (String) Dataset description.
 - `freshness` (String) Target freshness for results. Tighten the freshness to increase the
 frequency with which queries are run, which incurs higher transform costs.

--- a/observe/data_source_dataset.go
+++ b/observe/data_source_dataset.go
@@ -81,6 +81,11 @@ func dataSourceDataset() *schema.Resource {
 				Computed:    true,
 				Description: descriptions.Get("transform", "schema", "inputs"),
 			},
+			"data_table_view_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("dataset", "schema", "data_table_view_state"),
+			},
 			"stage": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/observe/descriptions/dataset.yaml
+++ b/observe/descriptions/dataset.yaml
@@ -13,3 +13,5 @@ schema:
     The maximum on-demand materialization length for the dataset.
   acceleration_disabled: |
     Disables periodic materialization of the dataset
+  data_table_view_state: |
+    JSON representation of state used for dataset formatting in the UI

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -109,6 +109,7 @@ func TestAccObserveDatasetUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.input", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.pipeline", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "acceleration_disabled", "false"),
+					resource.TestCheckResourceAttr("observe_dataset.first", "data_table_view_state", ""),
 				),
 			},
 			{
@@ -125,6 +126,7 @@ func TestAccObserveDatasetUpdate(t *testing.T) {
 					}
 
 					acceleration_disabled = true
+					data_table_view_state = jsonencode({viewType = "Auto"})
 
 					stage {
 					  pipeline = <<-EOF
@@ -141,6 +143,7 @@ func TestAccObserveDatasetUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.alias", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.input", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "acceleration_disabled", "true"),
+					resource.TestCheckResourceAttr("observe_dataset.first", "data_table_view_state", "{\"viewType\":\"Auto\"}"),
 				),
 			},
 			{

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -109,7 +109,6 @@ func TestAccObserveDatasetUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.input", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.pipeline", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "acceleration_disabled", "false"),
-					resource.TestCheckResourceAttr("observe_dataset.first", "data_table_view_state", ""),
 				),
 			},
 			{


### PR DESCRIPTION
Tested creating dataset with `data_table_view_state` specified, updating it, and going through the equivalent of what Export Terraform does.