### PR TITLE
feat: Add correlation tags to dataset datasource schema

### DIFF
--- a/client/internal/meta/operation/dataset.graphql
+++ b/client/internal/meta/operation/dataset.graphql
@@ -62,6 +62,13 @@ fragment Dataset on Dataset {
 			sqlType
 		}
 	}
+	correlationTagMappings {
+		tag
+		path {
+			column
+			path
+		}
+	}
 }
 
 fragment DatasetIdName on Dataset {

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -1254,12 +1254,13 @@ type Dataset struct {
 	ManagedById          *string            `json:"managedById"`
 	// Optional custom configured override value of the on demand materialization
 	// range for the dataset.
-	OnDemandMaterializationLength *types.Int64Scalar                       `json:"onDemandMaterializationLength"`
-	DataTableViewState            *types.JsonObject                        `json:"dataTableViewState"`
-	ForeignKeys                   []DatasetForeignKeysForeignKey           `json:"foreignKeys"`
-	Transform                     *DatasetTransform                        `json:"transform"`
-	Typedef                       DatasetTypedef                           `json:"typedef"`
-	SourceTable                   *DatasetSourceTableSourceTableDefinition `json:"sourceTable"`
+	OnDemandMaterializationLength *types.Int64Scalar                                   `json:"onDemandMaterializationLength"`
+	DataTableViewState            *types.JsonObject                                    `json:"dataTableViewState"`
+	ForeignKeys                   []DatasetForeignKeysForeignKey                       `json:"foreignKeys"`
+	Transform                     *DatasetTransform                                    `json:"transform"`
+	Typedef                       DatasetTypedef                                       `json:"typedef"`
+	SourceTable                   *DatasetSourceTableSourceTableDefinition             `json:"sourceTable"`
+	CorrelationTagMappings        []DatasetCorrelationTagMappingsCorrelationTagMapping `json:"correlationTagMappings"`
 }
 
 // GetWorkspaceId returns Dataset.WorkspaceId, and is useful for accessing the field via an interface.
@@ -1317,6 +1318,41 @@ func (v *Dataset) GetTypedef() DatasetTypedef { return v.Typedef }
 
 // GetSourceTable returns Dataset.SourceTable, and is useful for accessing the field via an interface.
 func (v *Dataset) GetSourceTable() *DatasetSourceTableSourceTableDefinition { return v.SourceTable }
+
+// GetCorrelationTagMappings returns Dataset.CorrelationTagMappings, and is useful for accessing the field via an interface.
+func (v *Dataset) GetCorrelationTagMappings() []DatasetCorrelationTagMappingsCorrelationTagMapping {
+	return v.CorrelationTagMappings
+}
+
+// DatasetCorrelationTagMappingsCorrelationTagMapping includes the requested fields of the GraphQL type CorrelationTagMapping.
+type DatasetCorrelationTagMappingsCorrelationTagMapping struct {
+	Tag  string                                                          `json:"tag"`
+	Path DatasetCorrelationTagMappingsCorrelationTagMappingPathLinkField `json:"path"`
+}
+
+// GetTag returns DatasetCorrelationTagMappingsCorrelationTagMapping.Tag, and is useful for accessing the field via an interface.
+func (v *DatasetCorrelationTagMappingsCorrelationTagMapping) GetTag() string { return v.Tag }
+
+// GetPath returns DatasetCorrelationTagMappingsCorrelationTagMapping.Path, and is useful for accessing the field via an interface.
+func (v *DatasetCorrelationTagMappingsCorrelationTagMapping) GetPath() DatasetCorrelationTagMappingsCorrelationTagMappingPathLinkField {
+	return v.Path
+}
+
+// DatasetCorrelationTagMappingsCorrelationTagMappingPathLinkField includes the requested fields of the GraphQL type LinkField.
+type DatasetCorrelationTagMappingsCorrelationTagMappingPathLinkField struct {
+	Column string  `json:"column"`
+	Path   *string `json:"path"`
+}
+
+// GetColumn returns DatasetCorrelationTagMappingsCorrelationTagMappingPathLinkField.Column, and is useful for accessing the field via an interface.
+func (v *DatasetCorrelationTagMappingsCorrelationTagMappingPathLinkField) GetColumn() string {
+	return v.Column
+}
+
+// GetPath returns DatasetCorrelationTagMappingsCorrelationTagMappingPathLinkField.Path, and is useful for accessing the field via an interface.
+func (v *DatasetCorrelationTagMappingsCorrelationTagMappingPathLinkField) GetPath() *string {
+	return v.Path
+}
 
 type DatasetDefinitionInput struct {
 	Dataset  DatasetInput                    `json:"dataset"`
@@ -15364,6 +15400,13 @@ fragment Dataset on Dataset {
 			sqlType
 		}
 	}
+	correlationTagMappings {
+		tag
+		path {
+			column
+			path
+		}
+	}
 }
 fragment StageQuery on StageQuery {
 	id
@@ -17134,6 +17177,13 @@ fragment Dataset on Dataset {
 			sqlType
 		}
 	}
+	correlationTagMappings {
+		tag
+		path {
+			column
+			path
+		}
+	}
 }
 fragment StageQuery on StageQuery {
 	id
@@ -17452,6 +17502,13 @@ fragment Dataset on Dataset {
 		fields {
 			name
 			sqlType
+		}
+	}
+	correlationTagMappings {
+		tag
+		path {
+			column
+			path
 		}
 	}
 }
@@ -18274,6 +18331,13 @@ fragment Dataset on Dataset {
 			sqlType
 		}
 	}
+	correlationTagMappings {
+		tag
+		path {
+			column
+			path
+		}
+	}
 }
 fragment StageQuery on StageQuery {
 	id
@@ -18583,6 +18647,13 @@ fragment Dataset on Dataset {
 		fields {
 			name
 			sqlType
+		}
+	}
+	correlationTagMappings {
+		tag
+		path {
+			column
+			path
 		}
 	}
 }

--- a/docs/data-sources/dataset.md
+++ b/docs/data-sources/dataset.md
@@ -28,7 +28,6 @@ data "observe_datastet" "example" {
 
 ### Optional
 
-- `correlation_tag` (Block List) Correlation tags associated with this dataset. (see [below for nested schema](#nestedblock--correlation_tag))
 - `id` (String) Resource ID for this object.
 One of `name` or `id` must be set.
 - `name` (String) Dataset name. Must be unique within workspace.
@@ -38,6 +37,7 @@ One of `name` or `id` must be set. If `name` is provided, `workspace` must be se
 ### Read-Only
 
 - `acceleration_disabled` (Boolean)
+- `correlation_tag` (Block List) Correlation tags associated with this dataset. (see [below for nested schema](#nestedblock--correlation_tag))
 - `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI
 - `description` (String) Dataset description.
 - `freshness` (String) Target freshness for results. Tighten the freshness to increase the
@@ -58,13 +58,10 @@ its predecessor. (see [below for nested schema](#nestedblock--stage))
 <a id="nestedblock--correlation_tag"></a>
 ### Nested Schema for `correlation_tag`
 
-Required:
+Read-Only:
 
 - `column` (String) The column to which the correlation tag should be attached.
 - `name` (String) The name to attach.
-
-Optional:
-
 - `path` (String) If the column is of type "object", a correlation tag can be attached to a
 key nested within the object. Standard Javascript notation can be used to specify the path to the key.
 For example, say the object has the following structure -

--- a/docs/data-sources/dataset.md
+++ b/docs/data-sources/dataset.md
@@ -28,6 +28,7 @@ data "observe_datastet" "example" {
 
 ### Optional
 
+- `correlation_tag` (Block List) Correlation tags associated with this dataset. (see [below for nested schema](#nestedblock--correlation_tag))
 - `id` (String) Resource ID for this object.
 One of `name` or `id` must be set.
 - `name` (String) Dataset name. Must be unique within workspace.
@@ -53,6 +54,29 @@ paths between two datasets.
 - `stage` (Block List) A stage processes an input according to the provided pipeline. If no
 input is provided, a stage will implicitly follow on from the result of
 its predecessor. (see [below for nested schema](#nestedblock--stage))
+
+<a id="nestedblock--correlation_tag"></a>
+### Nested Schema for `correlation_tag`
+
+Required:
+
+- `column` (String) The column to which the correlation tag should be attached.
+- `name` (String) The name to attach.
+
+Optional:
+
+- `path` (String) If the column is of type "object", a correlation tag can be attached to a
+key nested within the object. Standard Javascript notation can be used to specify the path to the key.
+For example, say the object has the following structure -
+{
+  "a": {
+    "b": {
+      "c": "value"
+    }
+  }
+}
+Then the path to the key "c" would be "a.b.c" or "a['b']['c']"
+
 
 <a id="nestedblock--stage"></a>
 ### Nested Schema for `stage`

--- a/observe/data_source_dataset.go
+++ b/observe/data_source_dataset.go
@@ -127,22 +127,21 @@ func dataSourceDataset() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						correlationTagNameKey: {
 							Type:        schema.TypeString,
-							Required:    true,
+							Computed:    true,
 							Description: descriptions.Get("correlation_tag", "schema", correlationTagNameKey),
 							ForceNew:    true,
 						},
 						correlationTagColumnKey: {
 							Type:        schema.TypeString,
-							Required:    true,
+							Computed:    true,
 							Description: descriptions.Get("correlation_tag", "schema", correlationTagColumnKey),
 							ForceNew:    true,
 						},
 						correlationTagPathKey: {
 							Type:        schema.TypeString,
-							Required:    false,
+							Computed:    true,
 							Description: descriptions.Get("correlation_tag", "schema", correlationTagPathKey),
 							ForceNew:    true,
-							Optional:    true,
 						},
 					},
 				},

--- a/observe/data_source_dataset.go
+++ b/observe/data_source_dataset.go
@@ -118,6 +118,35 @@ func dataSourceDataset() *schema.Resource {
 					},
 				},
 			},
+			"correlation_tag": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Optional:    true,
+				Description: descriptions.Get("dataset", "schema", "correlation_tag", "description"),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						correlationTagNameKey: {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: descriptions.Get("correlation_tag", "schema", correlationTagNameKey),
+							ForceNew:    true,
+						},
+						correlationTagColumnKey: {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: descriptions.Get("correlation_tag", "schema", correlationTagColumnKey),
+							ForceNew:    true,
+						},
+						correlationTagPathKey: {
+							Type:        schema.TypeString,
+							Required:    false,
+							Description: descriptions.Get("correlation_tag", "schema", correlationTagPathKey),
+							ForceNew:    true,
+							Optional:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -156,5 +185,17 @@ func dataSourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta 
 	}
 	data.SetId(d.Id)
 
-	return datasetToResourceData(d, data)
+	diags = datasetToResourceData(d, data)
+	if d.CorrelationTagMappings != nil {
+		var cts []interface{}
+		for _, ct := range d.CorrelationTagMappings {
+			cts = append(cts, map[string]interface{}{
+				correlationTagNameKey:   ct.Tag,
+				correlationTagColumnKey: ct.Path.Column,
+				correlationTagPathKey:   ct.Path.Path,
+			})
+		}
+		data.Set("correlation_tag", cts)
+	}
+	return
 }

--- a/observe/data_source_dataset_test.go
+++ b/observe/data_source_dataset_test.go
@@ -159,3 +159,54 @@ func TestAccObserveSourceDatasetInvalidID(t *testing.T) {
 		},
 	})
 }
+
+func TestAccObserveSourceDatasetStageCorrelationTag(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(configPreamble+`
+						resource "observe_datastream" "a" {
+							workspace = data.observe_workspace.default.oid
+							name      = "%[1]s"
+						}
+
+						resource "observe_dataset" "b" {
+							workspace = data.observe_workspace.default.oid
+							name      = "%[1]s-b"
+
+							inputs = { "a" = observe_datastream.a.dataset }
+
+							stage {
+								pipeline = <<-EOF
+									filter false
+									colmake key:"test"
+								EOF
+							}
+						}
+
+						resource "observe_correlation_tag" "ctag_1" {
+							column = "key"
+							dataset = observe_dataset.b.oid
+							name = "first_correlation_tag"
+						}
+
+						data "observe_dataset" "lookup_by_id" {
+							id = observe_dataset.b.id
+							depends_on = [observe_correlation_tag.ctag_1]
+						}
+					`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.observe_dataset.lookup_by_id", "workspace"),
+					resource.TestCheckResourceAttr("data.observe_dataset.lookup_by_id", "name", randomPrefix+"-b"),
+					resource.TestCheckResourceAttr("data.observe_dataset.lookup_by_id", "stage.0.pipeline", "filter false\ncolmake key:\"test\"\n"),
+					resource.TestCheckResourceAttr("data.observe_dataset.lookup_by_id", "correlation_tag.0.name", "first_correlation_tag"),
+					resource.TestCheckResourceAttr("data.observe_dataset.lookup_by_id", "correlation_tag.0.column", "key"),
+				),
+			},
+		},
+	})
+}

--- a/observe/descriptions/dataset.yaml
+++ b/observe/descriptions/dataset.yaml
@@ -15,3 +15,6 @@ schema:
     Disables periodic materialization of the dataset
   data_table_view_state: |
     JSON representation of state used for dataset formatting in the UI
+  correlation_tag:
+    description: |
+      Correlation tags associated with this dataset.


### PR DESCRIPTION
This should be exposed for downstream consumption so users can obtain the set of correlation tags currently attached to their datasets.