### PR TITLE
OB-37347: Update terraform API to handle acceleration disabled source

### DIFF
--- a/client/internal/meta/operation/dataset.graphql
+++ b/client/internal/meta/operation/dataset.graphql
@@ -6,6 +6,7 @@ fragment Dataset on Dataset {
 	description
 	iconUrl
 	accelerationDisabled
+	accelerationDisabledSource
 	version
 	updatedDate
 	pathCost
@@ -78,6 +79,7 @@ fragment DatasetIdName on Dataset {
 
 # @genqlient(for: "DatasetInput.deleted", omitempty: true)
 # @genqlient(for: "DatasetInput.accelerationDisabled", omitempty: true)
+# @genqlient(for: "DatasetInput.accelerationDisabledSource", omitempty: true)
 # @genqlient(for: "InputDefinitionInput.stageID", omitempty: true)
 # @genqlient(for: "InputDefinitionInput.stageId", omitempty: true)
 # @genqlient(for: "StageQueryInput.stageID", omitempty: true)
@@ -147,6 +149,7 @@ query listDatasetsIdNameOnly {
 # @genqlient(for: "DatasetFieldTypeInput.nullable", omitempty: true)
 # @genqlient(for: "DatasetInput.deleted", omitempty: true)
 # @genqlient(for: "DatasetInput.accelerationDisabled", omitempty: true)
+# @genqlient(for: "DatasetInput.accelerationDisabledSource", omitempty: true)
 # @genqlient(for: "InputDefinitionInput.stageID", omitempty: true)
 # @genqlient(for: "InputDefinitionInput.stageId", omitempty: true)
 # @genqlient(for: "StageQueryInput.stageID", omitempty: true)

--- a/client/internal/meta/schema/dataset.graphql
+++ b/client/internal/meta/schema/dataset.graphql
@@ -321,6 +321,12 @@ type DatasetInputDataset @goModel(model: "observe/meta/metatypes.DatasetInputDat
     inputRole: InputRole!,
 }
 
+enum AccelerationDisabledSource @goModel(model:"observe/meta/metatypes.DatasetMaterializationDisabledSource") {
+    Empty
+    Monitor
+    View
+}
+
 type Dataset implements WorkspaceObject & FolderObject & AuditedObject & AccelerableObject @goModel(model: "observe/meta/metatypes.Dataset") {
     id: ObjectId!
     version: Time!
@@ -379,6 +385,7 @@ type Dataset implements WorkspaceObject & FolderObject & AuditedObject & Acceler
     accelerable: Boolean!
     accelerationInfo: AccelerationInfo! @goField(forceResolver:true)
     accelerationDisabled: Boolean! @goField(name:materializationDisabled)
+    accelerationDisabledSource: AccelerationDisabledSource! @goField(name:materializationDisabledSource)
 
     """
     If the dataset is not hibernated, this field will be set to null.
@@ -591,7 +598,18 @@ input DatasetInput @goModel(model: "observe/meta/metatypes.DatasetInput") {
     """
     overwriteSource: Boolean
     deleted: Boolean
+    """
+    Specifies if dataset acceleration should be disabled. Set to true if
+    dataset materialization is not desired. Defaults to false.
+    """
     accelerationDisabled: Boolean @goField(name:materializationDisabled)
+    """
+    Optional reason given for why a dataset is not accelerated. For example,
+    when creating a dataset view, user must set accelerationDisabled to true
+    and set accelerationDisabledSource to 'View'. Options include: 'Empty',
+    'Monitor', and 'View'. Defaults to 'Empty'.
+    """
+    accelerationDisabledSource: AccelerationDisabledSource @goField(name:materializationDisabledSource)
     latencyDesired: Int64
     freshnessDesired: Int64
     iconUrl: String

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -11,6 +11,14 @@ import (
 	"github.com/observeinc/terraform-provider-observe/client/meta/types"
 )
 
+type AccelerationDisabledSource string
+
+const (
+	AccelerationDisabledSourceEmpty   AccelerationDisabledSource = "Empty"
+	AccelerationDisabledSourceMonitor AccelerationDisabledSource = "Monitor"
+	AccelerationDisabledSourceView    AccelerationDisabledSource = "View"
+)
+
 type ActionInput struct {
 	Name             *string               `json:"name"`
 	IconUrl          *string               `json:"iconUrl"`
@@ -1240,18 +1248,19 @@ func (v *DashboardStagesStageQueryInputInputDefinition) GetStageId() *string { r
 
 // Dataset includes the GraphQL fields of Dataset requested by the fragment Dataset.
 type Dataset struct {
-	WorkspaceId          string             `json:"workspaceId"`
-	Id                   string             `json:"id"`
-	Name                 string             `json:"name"`
-	FreshnessDesired     *types.Int64Scalar `json:"freshnessDesired"`
-	Description          *string            `json:"description"`
-	IconUrl              *string            `json:"iconUrl"`
-	AccelerationDisabled bool               `json:"accelerationDisabled"`
-	Version              types.TimeScalar   `json:"version"`
-	UpdatedDate          types.TimeScalar   `json:"updatedDate"`
-	PathCost             *types.Int64Scalar `json:"pathCost"`
-	Source               *string            `json:"source"`
-	ManagedById          *string            `json:"managedById"`
+	WorkspaceId                string                     `json:"workspaceId"`
+	Id                         string                     `json:"id"`
+	Name                       string                     `json:"name"`
+	FreshnessDesired           *types.Int64Scalar         `json:"freshnessDesired"`
+	Description                *string                    `json:"description"`
+	IconUrl                    *string                    `json:"iconUrl"`
+	AccelerationDisabled       bool                       `json:"accelerationDisabled"`
+	AccelerationDisabledSource AccelerationDisabledSource `json:"accelerationDisabledSource"`
+	Version                    types.TimeScalar           `json:"version"`
+	UpdatedDate                types.TimeScalar           `json:"updatedDate"`
+	PathCost                   *types.Int64Scalar         `json:"pathCost"`
+	Source                     *string                    `json:"source"`
+	ManagedById                *string                    `json:"managedById"`
 	// Optional custom configured override value of the on demand materialization
 	// range for the dataset.
 	OnDemandMaterializationLength *types.Int64Scalar                                   `json:"onDemandMaterializationLength"`
@@ -1283,6 +1292,11 @@ func (v *Dataset) GetIconUrl() *string { return v.IconUrl }
 
 // GetAccelerationDisabled returns Dataset.AccelerationDisabled, and is useful for accessing the field via an interface.
 func (v *Dataset) GetAccelerationDisabled() bool { return v.AccelerationDisabled }
+
+// GetAccelerationDisabledSource returns Dataset.AccelerationDisabledSource, and is useful for accessing the field via an interface.
+func (v *Dataset) GetAccelerationDisabledSource() AccelerationDisabledSource {
+	return v.AccelerationDisabledSource
+}
 
 // GetVersion returns Dataset.Version, and is useful for accessing the field via an interface.
 func (v *Dataset) GetVersion() types.TimeScalar { return v.Version }
@@ -1482,15 +1496,22 @@ type DatasetInput struct {
 	// Format - source/comment. Examples - monitor/471142069, web/user created.
 	Source *string `json:"source"`
 	// Used only when id is specified - that is to say, only when the dataset is updated.
-	OverwriteSource      *bool              `json:"overwriteSource"`
-	Deleted              *bool              `json:"deleted,omitempty"`
-	AccelerationDisabled *bool              `json:"accelerationDisabled,omitempty"`
-	LatencyDesired       *types.Int64Scalar `json:"latencyDesired"`
-	FreshnessDesired     *types.Int64Scalar `json:"freshnessDesired"`
-	IconUrl              *string            `json:"iconUrl"`
-	Layout               *types.JsonObject  `json:"layout"`
-	PathCost             *types.Int64Scalar `json:"pathCost"`
-	DataTableViewState   *types.JsonObject  `json:"dataTableViewState"`
+	OverwriteSource *bool `json:"overwriteSource"`
+	Deleted         *bool `json:"deleted,omitempty"`
+	// Specifies if dataset acceleration should be disabled. Set to true if
+	// dataset materialization is not desired. Defaults to false.
+	AccelerationDisabled *bool `json:"accelerationDisabled,omitempty"`
+	// Optional reason given for why a dataset is not accelerated. For example,
+	// when creating a dataset view, user must set accelerationDisabled to true
+	// and set accelerationDisabledSource to 'View'. Options include: 'Empty',
+	// 'Monitor', and 'View'. Defaults to 'Empty'.
+	AccelerationDisabledSource *AccelerationDisabledSource `json:"accelerationDisabledSource,omitempty"`
+	LatencyDesired             *types.Int64Scalar          `json:"latencyDesired"`
+	FreshnessDesired           *types.Int64Scalar          `json:"freshnessDesired"`
+	IconUrl                    *string                     `json:"iconUrl"`
+	Layout                     *types.JsonObject           `json:"layout"`
+	PathCost                   *types.Int64Scalar          `json:"pathCost"`
+	DataTableViewState         *types.JsonObject           `json:"dataTableViewState"`
 	// Max on-demand materialization length for the dataset (in nanoseconds). If not set
 	// will use the default value in transformer config.
 	OnDemandMaterializationLength *types.Int64Scalar `json:"onDemandMaterializationLength"`
@@ -1518,6 +1539,11 @@ func (v *DatasetInput) GetDeleted() *bool { return v.Deleted }
 
 // GetAccelerationDisabled returns DatasetInput.AccelerationDisabled, and is useful for accessing the field via an interface.
 func (v *DatasetInput) GetAccelerationDisabled() *bool { return v.AccelerationDisabled }
+
+// GetAccelerationDisabledSource returns DatasetInput.AccelerationDisabledSource, and is useful for accessing the field via an interface.
+func (v *DatasetInput) GetAccelerationDisabledSource() *AccelerationDisabledSource {
+	return v.AccelerationDisabledSource
+}
 
 // GetLatencyDesired returns DatasetInput.LatencyDesired, and is useful for accessing the field via an interface.
 func (v *DatasetInput) GetLatencyDesired() *types.Int64Scalar { return v.LatencyDesired }
@@ -15346,6 +15372,7 @@ fragment Dataset on Dataset {
 	description
 	iconUrl
 	accelerationDisabled
+	accelerationDisabledSource
 	version
 	updatedDate
 	pathCost
@@ -17123,6 +17150,7 @@ fragment Dataset on Dataset {
 	description
 	iconUrl
 	accelerationDisabled
+	accelerationDisabledSource
 	version
 	updatedDate
 	pathCost
@@ -17450,6 +17478,7 @@ fragment Dataset on Dataset {
 	description
 	iconUrl
 	accelerationDisabled
+	accelerationDisabledSource
 	version
 	updatedDate
 	pathCost
@@ -18277,6 +18306,7 @@ fragment Dataset on Dataset {
 	description
 	iconUrl
 	accelerationDisabled
+	accelerationDisabledSource
 	version
 	updatedDate
 	pathCost
@@ -18595,6 +18625,7 @@ fragment Dataset on Dataset {
 	description
 	iconUrl
 	accelerationDisabled
+	accelerationDisabledSource
 	version
 	updatedDate
 	pathCost

--- a/client/meta/helpers.go
+++ b/client/meta/helpers.go
@@ -153,6 +153,12 @@ var AllMonitorV2HttpTypes = []MonitorV2HttpType{
 	MonitorV2HttpTypePut,
 }
 
+var AllAccelerationDisabledSource = []AccelerationDisabledSource{
+	AccelerationDisabledSourceEmpty,
+	AccelerationDisabledSourceMonitor,
+	AccelerationDisabledSourceView,
+}
+
 const (
 	ErrNotFound = "NOT_FOUND"
 )

--- a/docs/data-sources/dataset.md
+++ b/docs/data-sources/dataset.md
@@ -37,6 +37,7 @@ One of `name` or `id` must be set. If `name` is provided, `workspace` must be se
 ### Read-Only
 
 - `acceleration_disabled` (Boolean)
+- `acceleration_disabled_source` (String)
 - `correlation_tag` (Block List) Correlation tags associated with this dataset. (see [below for nested schema](#nestedblock--correlation_tag))
 - `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI
 - `description` (String) Dataset description.

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -50,6 +50,7 @@ its predecessor. (see [below for nested schema](#nestedblock--stage))
 ### Optional
 
 - `acceleration_disabled` (Boolean) Disables periodic materialization of the dataset
+- `acceleration_disabled_source` (String) Source of disabled materialization
 - `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI
 - `description` (String) Dataset description.
 - `freshness` (String) Target freshness for results. Tighten the freshness to increase the

--- a/observe/data_source_dataset.go
+++ b/observe/data_source_dataset.go
@@ -61,6 +61,10 @@ func dataSourceDataset() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"acceleration_disabled_source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"path_cost": {
 				Type:        schema.TypeInt,
 				Computed:    true,

--- a/observe/descriptions/dataset.yaml
+++ b/observe/descriptions/dataset.yaml
@@ -13,6 +13,8 @@ schema:
     The maximum on-demand materialization length for the dataset.
   acceleration_disabled: |
     Disables periodic materialization of the dataset
+  acceleration_disabled_source: |
+    Source of disabled materialization
   data_table_view_state: |
     JSON representation of state used for dataset formatting in the UI
   correlation_tag:

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -93,6 +93,12 @@ func resourceDataset() *schema.Resource {
 				Default:     false,
 				Description: descriptions.Get("dataset", "schema", "acceleration_disabled"),
 			},
+			"acceleration_disabled_source": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateEnums(gql.AllAccelerationDisabledSource),
+				Description:      descriptions.Get("dataset", "schema", "acceleration_disabled_source"),
+			},
 			"inputs": {
 				Type:             schema.TypeMap,
 				Required:         true,
@@ -192,6 +198,11 @@ func newDatasetConfig(data *schema.ResourceData) (*gql.DatasetInput, *gql.MultiS
 	b := data.Get("acceleration_disabled").(bool)
 	input.AccelerationDisabled = &b
 
+	if v, ok := data.GetOk("acceleration_disabled_source"); ok {
+		c := gql.AccelerationDisabledSource(toCamel(v.(string)))
+		input.AccelerationDisabledSource = &c
+	}
+
 	if v, ok := data.GetOk("path_cost"); ok {
 		input.PathCost = types.Int64Scalar(v.(int)).Ptr()
 	} else {
@@ -240,6 +251,10 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData) (diags dia
 	}
 
 	if err := data.Set("acceleration_disabled", d.AccelerationDisabled); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+
+	if err := data.Set("acceleration_disabled_source", toSnake(string(d.AccelerationDisabledSource))); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -109,6 +109,7 @@ func TestAccObserveDatasetUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.input", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.pipeline", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "acceleration_disabled", "false"),
+					resource.TestCheckResourceAttr("observe_dataset.first", "acceleration_disabled_source", ""),
 				),
 			},
 			{
@@ -125,6 +126,7 @@ func TestAccObserveDatasetUpdate(t *testing.T) {
 					}
 
 					acceleration_disabled = true
+					acceleration_disabled_source = "view"
 					data_table_view_state = jsonencode({viewType = "Auto"})
 
 					stage {
@@ -143,6 +145,7 @@ func TestAccObserveDatasetUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.input", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "acceleration_disabled", "true"),
 					resource.TestCheckResourceAttr("observe_dataset.first", "data_table_view_state", "{\"viewType\":\"Auto\"}"),
+					resource.TestCheckResourceAttr("observe_dataset.first", "acceleration_disabled_source", "view"),
 				),
 			},
 			{


### PR DESCRIPTION
Should not be merged until GQL support hits all clusters (OB-36860).