### PR TITLE
feat: resource_grant minor updates

### DIFF
--- a/docs/data-sources/rbac_group.md
+++ b/docs/data-sources/rbac_group.md
@@ -17,10 +17,10 @@ data "observe_rbac_group" "example" {
   name = "example"
 }
 
-// In RBAC v2, "everyone" is a special pre-defined group that always includes all users.
+// In RBAC v2, "Everyone" is a special pre-defined group that always includes all users.
 // Reach out to Observe to enable this feature.
 data "observe_rbac_group" "everyone" {
-  name = "everyone"
+  name = "Everyone"
 }
 ```
 

--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -29,9 +29,9 @@ data "observe_rbac_group" "example" {
   name = "engineering"
 }
 
-// "everyone" is a special pre-defined group that always includes all users
+// "Everyone" is a special pre-defined group that always includes all users
 data "observe_rbac_group" "everyone" {
-  name = "everyone"
+  name = "Everyone"
 }
 
 data "observe_dataset" "example" {

--- a/examples/data-sources/observe_rbac_group/data-source.tf
+++ b/examples/data-sources/observe_rbac_group/data-source.tf
@@ -2,8 +2,8 @@ data "observe_rbac_group" "example" {
   name = "example"
 }
 
-// In RBAC v2, "everyone" is a special pre-defined group that always includes all users.
+// In RBAC v2, "Everyone" is a special pre-defined group that always includes all users.
 // Reach out to Observe to enable this feature.
 data "observe_rbac_group" "everyone" {
-  name = "everyone"
+  name = "Everyone"
 }

--- a/examples/resources/observe_grant/resource.tf
+++ b/examples/resources/observe_grant/resource.tf
@@ -10,9 +10,9 @@ data "observe_rbac_group" "example" {
   name = "engineering"
 }
 
-// "everyone" is a special pre-defined group that always includes all users
+// "Everyone" is a special pre-defined group that always includes all users
 data "observe_rbac_group" "everyone" {
-  name = "everyone"
+  name = "Everyone"
 }
 
 data "observe_dataset" "example" {

--- a/observe/data_source_rbac_group.go
+++ b/observe/data_source_rbac_group.go
@@ -63,17 +63,6 @@ func dataSourceRbacGroupRead(ctx context.Context, data *schema.ResourceData, met
 		r, err = client.GetRbacGroup(ctx, explicitId)
 	} else if name != "" {
 		r, err = client.LookupRbacGroup(ctx, name)
-
-		// In RBAC v2, "everyone" is a special group with id "1" that always includes all users.
-		// To prevent issues for customers who have a real group named "everyone", only
-		// return this special group if the lookup failed.
-		if err != nil && name == "everyone" {
-			r = &gql.RbacGroup{
-				Id:   "1",
-				Name: "everyone",
-			}
-			err = nil
-		}
 	}
 
 	if err != nil {

--- a/observe/resource_grant.go
+++ b/observe/resource_grant.go
@@ -29,12 +29,14 @@ func resourceGrant() *schema.Resource {
 				Required:         true,
 				ValidateDiagFunc: validateOID(oid.TypeUser, oid.TypeRbacGroup),
 				Description:      descriptions.Get("grant", "schema", "subject"),
+				ForceNew:         true,
 			},
 			"role": {
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateDiagFunc: validateEnums(validGrantRoles),
 				Description:      descriptions.Get("grant", "schema", "role"),
+				ForceNew:         true,
 			},
 			"qualifier": {
 				Type:     schema.TypeList,
@@ -52,6 +54,7 @@ func resourceGrant() *schema.Resource {
 						// in the future, will contain other qualifiers such as "tags"
 					},
 				},
+				ForceNew: true,
 			},
 			"oid": {
 				Type:     schema.TypeString,
@@ -80,11 +83,7 @@ func newGrantInput(data *schema.ResourceData) (input *gql.RbacStatementInput, di
 		}
 		input.Subject.UserId = &uid
 	} else if subject.Type == oid.TypeRbacGroup {
-		if subject.Id == "1" {
-			input.Subject.All = boolPtr(true)
-		} else {
-			input.Subject.GroupId = &subject.Id
-		}
+		input.Subject.GroupId = &subject.Id
 	}
 
 	// role
@@ -122,9 +121,7 @@ func grantToResourceData(stmt *gql.RbacStatement, data *schema.ResourceData) (di
 
 	// subject
 	subject := ""
-	if stmt.Subject.All != nil && *stmt.Subject.All {
-		subject = oid.RbacGroupOid("1").String()
-	} else if stmt.Subject.UserId != nil {
+	if stmt.Subject.UserId != nil {
 		subject = oid.UserOid(*stmt.Subject.UserId).String()
 	} else if stmt.Subject.GroupId != nil {
 		subject = oid.RbacGroupOid(*stmt.Subject.GroupId).String()

--- a/observe/resource_grant_test.go
+++ b/observe/resource_grant_test.go
@@ -92,7 +92,7 @@ func TestAccObserveGrantEveryoneWorksheetView(t *testing.T) {
 			{
 				Config: fmt.Sprintf(configPreamble+datastreamConfigPreamble+`
 				data "observe_rbac_group" "everyone" {
-				  name = "everyone"
+				  name = "Everyone"
 				}
 
 				data "observe_oid" "dataset" {


### PR DESCRIPTION
- rbac v2 grants are now immutable, added ForceNew to each field
- stop using the Subject.All field when converting to v1 statements (handled automatically with the GroupId)
- the api will now return "Everyone" as a real group, no need to handle it in the provider