### PR TITLE
Update dataset version field to use lastSaved instead of updatedDate

### DIFF
--- a/client/internal/meta/operation/dataset.graphql
+++ b/client/internal/meta/operation/dataset.graphql
@@ -8,7 +8,7 @@ fragment Dataset on Dataset {
 	accelerationDisabled
 	accelerationDisabledSource
 	version
-	updatedDate
+	lastSaved
 	pathCost
 	source
 	managedById

--- a/client/internal/meta/schema/dataset.graphql
+++ b/client/internal/meta/schema/dataset.graphql
@@ -376,6 +376,7 @@ type Dataset implements WorkspaceObject & FolderObject & AuditedObject & Acceler
     correlationTagMappings: [CorrelationTagMapping!] @goField(forceResolver:false)
     latestPublished: Time @deprecated(reason: "use version instead") @goField(name:version)
     versions: [Time!] @goField(forceResolver:true)
+    lastSaved: Time!
     isSourceDataset: Boolean
     transform: Transform @goField(forceResolver:true)
     inputs: [DatasetInputDataset!] @goField(forceResolver:true)

--- a/client/meta/dataset.go
+++ b/client/meta/dataset.go
@@ -94,7 +94,7 @@ func (client *Client) SaveSourceDataset(ctx context.Context, workspaceId string,
 }
 
 func (d *Dataset) Oid() *oid.OID {
-	version := d.UpdatedDate.String()
+	version := d.LastSaved.String()
 	return &oid.OID{
 		Id:      d.Id,
 		Type:    oid.TypeDataset,

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -1257,7 +1257,7 @@ type Dataset struct {
 	AccelerationDisabled       bool                       `json:"accelerationDisabled"`
 	AccelerationDisabledSource AccelerationDisabledSource `json:"accelerationDisabledSource"`
 	Version                    types.TimeScalar           `json:"version"`
-	UpdatedDate                types.TimeScalar           `json:"updatedDate"`
+	LastSaved                  types.TimeScalar           `json:"lastSaved"`
 	PathCost                   *types.Int64Scalar         `json:"pathCost"`
 	Source                     *string                    `json:"source"`
 	ManagedById                *string                    `json:"managedById"`
@@ -1301,8 +1301,8 @@ func (v *Dataset) GetAccelerationDisabledSource() AccelerationDisabledSource {
 // GetVersion returns Dataset.Version, and is useful for accessing the field via an interface.
 func (v *Dataset) GetVersion() types.TimeScalar { return v.Version }
 
-// GetUpdatedDate returns Dataset.UpdatedDate, and is useful for accessing the field via an interface.
-func (v *Dataset) GetUpdatedDate() types.TimeScalar { return v.UpdatedDate }
+// GetLastSaved returns Dataset.LastSaved, and is useful for accessing the field via an interface.
+func (v *Dataset) GetLastSaved() types.TimeScalar { return v.LastSaved }
 
 // GetPathCost returns Dataset.PathCost, and is useful for accessing the field via an interface.
 func (v *Dataset) GetPathCost() *types.Int64Scalar { return v.PathCost }
@@ -15397,7 +15397,7 @@ fragment Dataset on Dataset {
 	accelerationDisabled
 	accelerationDisabledSource
 	version
-	updatedDate
+	lastSaved
 	pathCost
 	source
 	managedById
@@ -17175,7 +17175,7 @@ fragment Dataset on Dataset {
 	accelerationDisabled
 	accelerationDisabledSource
 	version
-	updatedDate
+	lastSaved
 	pathCost
 	source
 	managedById
@@ -17503,7 +17503,7 @@ fragment Dataset on Dataset {
 	accelerationDisabled
 	accelerationDisabledSource
 	version
-	updatedDate
+	lastSaved
 	pathCost
 	source
 	managedById
@@ -18331,7 +18331,7 @@ fragment Dataset on Dataset {
 	accelerationDisabled
 	accelerationDisabledSource
 	version
-	updatedDate
+	lastSaved
 	pathCost
 	source
 	managedById
@@ -18650,7 +18650,7 @@ fragment Dataset on Dataset {
 	accelerationDisabled
 	accelerationDisabledSource
 	version
-	updatedDate
+	lastSaved
 	pathCost
 	source
 	managedById


### PR DESCRIPTION
This field is the proper one to use to determine when the last user modifications were made to a dataset which also excludes system modifications and is required to properly support an upcoming release