### PR TITLE
fix: prevent unnecessary diff for rematerialization_mode

### DIFF
--- a/client/meta/dataset.go
+++ b/client/meta/dataset.go
@@ -30,12 +30,6 @@ func DefaultDependencyHandling() *DependencyHandlingInput {
 	return &DependencyHandlingInput{SaveMode: &mode}
 }
 
-func DependencyHandlingSkipRematerialization() *DependencyHandlingInput {
-	saveMode := SaveModeUpdateDatasetAndDependenciesIgnoringAllErrors
-	rematMode := RematerializationModeSkiprematerialization
-	return &DependencyHandlingInput{SaveMode: &saveMode, RematerializationMode: &rematMode}
-}
-
 // SaveDataset creates and updates datasets
 func (client *Client) SaveDataset(ctx context.Context, workspaceId string, input *DatasetInput, queryInput *MultiStageQueryInput, dependencyHandling *DependencyHandlingInput) (*Dataset, error) {
 	resp, err := saveDataset(ctx, client.Gql, workspaceId, *input, *queryInput, dependencyHandling)

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -21,9 +21,6 @@ const (
 	schemaDatasetDescriptionDescription = "Dataset description."
 	schemaDatasetIconDescription        = "Icon image."
 	schemaDatasetOIDDescription         = "The Observe ID for dataset."
-
-	rematerializationModeRematerialize         = "rematerialize"
-	rematerializationModeSkipRematerialization = "skip_rematerialization"
 )
 
 func resourceDataset() *schema.Resource {
@@ -365,9 +362,10 @@ func resourceDatasetCreate(ctx context.Context, data *schema.ResourceData, meta 
 	}
 
 	dependencyHandling := gql.DefaultDependencyHandling()
-	switch data.Get("rematerialization_mode").(string) {
-	case rematerializationModeRematerialize:
-	case rematerializationModeSkipRematerialization:
+	rematerializationMode := gql.RematerializationMode(toCamel(data.Get("rematerialization_mode").(string)))
+	switch rematerializationMode {
+	case gql.RematerializationModeRematerialize:
+	case gql.RematerializationModeSkiprematerialization:
 		dependencyHandling = gql.DependencyHandlingSkipRematerialization()
 
 		diags = append(diags, diag.Diagnostic{
@@ -406,6 +404,14 @@ func resourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta in
 		})
 	}
 
+	// Since rematerialization_mode is not an actual property of the dataset, we don't have a value
+	// for it in the `result` from the API. So we set it to "rematerialize" (the default value)
+	// if it's not set, to prevent unnecessary diffs for existing dataset resources.
+	rematerializationMode := data.Get("rematerialization_mode").(string)
+	if rematerializationMode == "" {
+		data.Set("rematerialization_mode", toSnake(string(gql.RematerializationModeRematerialize)))
+	}
+
 	return datasetToResourceData(result, data)
 }
 
@@ -421,9 +427,10 @@ func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta 
 	wsid, _ := oid.NewOID(data.Get("workspace").(string))
 
 	dependencyHandling := gql.DefaultDependencyHandling()
-	switch data.Get("rematerialization_mode").(string) {
-	case rematerializationModeRematerialize:
-	case rematerializationModeSkipRematerialization:
+	rematerializationMode := gql.RematerializationMode(toCamel(data.Get("rematerialization_mode").(string)))
+	switch rematerializationMode {
+	case gql.RematerializationModeRematerialize:
+	case gql.RematerializationModeSkiprematerialization:
 		dependencyHandling = gql.DependencyHandlingSkipRematerialization()
 	}
 

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -112,7 +112,7 @@ func TestAccObserveDatasetUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.input", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.pipeline", ""),
 					resource.TestCheckResourceAttr("observe_dataset.first", "acceleration_disabled_source", "view"),
-					resource.TestCheckResourceAttr("observe_dataset.first", "rematerialization_mode", "rematerialize"),
+					resource.TestCheckNoResourceAttr("observe_dataset.first", "rematerialization_mode"),
 				),
 			},
 			{


### PR DESCRIPTION
Currently, for any existing dataset resources, the value for `rematerialization_mode` in the tfstate file is `""` since unlike for other fields that are set in `resourceDatasetRead`, `rematerialization_mode` isn't an actual property of datasets and there's no value for it returned by the API. This results in an unnecessary diff of `"" -> "rematerialize"` even though `rematerialize` is the default value.

To avoid this, I updated `resourceDatasetRead` to set `rematerialization_mode` to `rematerialize` if there's not already a value for it.