### PR TITLE
fix: remove omitempty directive from MonitorV2ActionInput.inline to prevent nondeterministic generation

### DIFF
--- a/client/internal/meta/operation/monitorv2.graphql
+++ b/client/internal/meta/operation/monitorv2.graphql
@@ -354,7 +354,6 @@ mutation saveMonitorV2Relations(
 # @genqlient(for: "PrimitiveValueInput.string", omitempty: true)
 # @genqlient(for: "PrimitiveValueInput.timestamp", omitempty: true)
 # @genqlient(for: "PrimitiveValueInput.duration", omitempty: true)
-# @genqlient(for: "MonitorV2ActionInput.inline", omitempty: true)
 # @genqlient(for: "MonitorV2ActionInput.email", omitempty: true)
 # @genqlient(for: "MonitorV2ActionInput.webhook", omitempty: true)
 # @genqlient(for: "MonitorV2ActionInput.iconUrl", omitempty: true)


### PR DESCRIPTION
The MonitorV2ActionInput type is used by multiple mutations, only one of which includes the genqlient directive to include `omitempty` in the generated Go type. This results in the generated type sometimes including omitempty and sometimes not, depending on the order in which the GraphQL files are processed.