### PR TITLE
fix: ensure lists of objects are exported as blocks for monitor v2

### DIFF
--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -52,7 +52,7 @@ its predecessor. (see [below for nested schema](#nestedblock--stage))
 Read-Only:
 
 - `action` (Block List) This value should be used for creating inline private actions. (see [below for nested schema](#nestedblock--actions--action))
-- `conditions` (List of Object) Optional conditions that can be AND'd with levels to match the action. (see [below for nested schema](#nestedatt--actions--conditions))
+- `conditions` (Block List) Optional conditions that can be AND'd with levels to match the action. (see [below for nested schema](#nestedblock--actions--conditions))
 - `levels` (List of String) The alarm level(s) at which this monitor should trigger this shared action.
 - `oid` (String) The OID of this shared action. This should be used for existing shared actions.
 - `send_end_notifications` (Boolean)
@@ -64,11 +64,11 @@ Read-Only:
 Read-Only:
 
 - `description` (String)
-- `email` (List of Object) (see [below for nested schema](#nestedatt--actions--action--email))
+- `email` (Block List) (see [below for nested schema](#nestedblock--actions--action--email))
 - `type` (String)
-- `webhook` (List of Object) (see [below for nested schema](#nestedatt--actions--action--webhook))
+- `webhook` (Block List) (see [below for nested schema](#nestedblock--actions--action--webhook))
 
-<a id="nestedatt--actions--action--email"></a>
+<a id="nestedblock--actions--action--email"></a>
 ### Nested Schema for `actions.action.email`
 
 Read-Only:
@@ -80,18 +80,18 @@ Read-Only:
 - `users` (List of String)
 
 
-<a id="nestedatt--actions--action--webhook"></a>
+<a id="nestedblock--actions--action--webhook"></a>
 ### Nested Schema for `actions.action.webhook`
 
 Read-Only:
 
 - `body` (String)
 - `fragments` (String)
-- `headers` (List of Object) (see [below for nested schema](#nestedobjatt--actions--action--webhook--headers))
+- `headers` (Block List) (see [below for nested schema](#nestedblock--actions--action--webhook--headers))
 - `method` (String)
 - `url` (String)
 
-<a id="nestedobjatt--actions--action--webhook--headers"></a>
+<a id="nestedblock--actions--action--webhook--headers"></a>
 ### Nested Schema for `actions.action.webhook.headers`
 
 Read-Only:
@@ -102,59 +102,59 @@ Read-Only:
 
 
 
-<a id="nestedatt--actions--conditions"></a>
+<a id="nestedblock--actions--conditions"></a>
 ### Nested Schema for `actions.conditions`
 
 Read-Only:
 
-- `compare_terms` (List of Object) (see [below for nested schema](#nestedobjatt--actions--conditions--compare_terms))
+- `compare_terms` (Block List) (see [below for nested schema](#nestedblock--actions--conditions--compare_terms))
 
-<a id="nestedobjatt--actions--conditions--compare_terms"></a>
+<a id="nestedblock--actions--conditions--compare_terms"></a>
 ### Nested Schema for `actions.conditions.compare_terms`
 
 Read-Only:
 
-- `column` (List of Object) (see [below for nested schema](#nestedobjatt--actions--conditions--compare_terms--column))
-- `comparison` (List of Object) (see [below for nested schema](#nestedobjatt--actions--conditions--compare_terms--comparison))
+- `column` (Block List) The column (left-side) value to evaluate (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column))
+- `comparison` (Block List) The comparison operation and right-side value to evaluate (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--comparison))
 
-<a id="nestedobjatt--actions--conditions--compare_terms--column"></a>
+<a id="nestedblock--actions--conditions--compare_terms--column"></a>
+### Nested Schema for `actions.conditions.compare_terms.column`
+
+Read-Only:
+
+- `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column--column_path))
+- `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column--link_column))
+
+<a id="nestedblock--actions--conditions--compare_terms--column--column_path"></a>
+### Nested Schema for `actions.conditions.compare_terms.column.column_path`
+
+Read-Only:
+
+- `name` (String) The name of the column.
+- `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--actions--conditions--compare_terms--column--link_column"></a>
+### Nested Schema for `actions.conditions.compare_terms.column.link_column`
+
+Read-Only:
+
+- `name` (String) The name of the link column.
+
+
+
+<a id="nestedblock--actions--conditions--compare_terms--comparison"></a>
 ### Nested Schema for `actions.conditions.compare_terms.comparison`
 
 Read-Only:
 
-- `column_path` (List of Object) (see [below for nested schema](#nestedobjatt--actions--conditions--compare_terms--comparison--column_path))
-- `link_column` (List of Object) (see [below for nested schema](#nestedobjatt--actions--conditions--compare_terms--comparison--link_column))
-
-<a id="nestedobjatt--actions--conditions--compare_terms--comparison--column_path"></a>
-### Nested Schema for `actions.conditions.compare_terms.comparison.column_path`
-
-Read-Only:
-
-- `name` (String)
-- `path` (String)
-
-
-<a id="nestedobjatt--actions--conditions--compare_terms--comparison--link_column"></a>
-### Nested Schema for `actions.conditions.compare_terms.comparison.link_column`
-
-Read-Only:
-
-- `name` (String)
-
-
-
-<a id="nestedobjatt--actions--conditions--compare_terms--comparison"></a>
-### Nested Schema for `actions.conditions.compare_terms.comparison`
-
-Read-Only:
-
-- `compare_fn` (String)
-- `value_bool` (List of Boolean)
-- `value_duration` (List of Boolean)
-- `value_float64` (List of Number)
-- `value_int64` (List of Number)
-- `value_string` (List of String)
-- `value_timestamp` (List of String)
+- `compare_fn` (String) the type of comparison (greater, less, equal, etc.)
+- `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
+- `value_duration` (List of Boolean) list of size <=1 consisting of a duration value.
+- `value_float64` (List of Number) list of size <=1 consisting of a float value.
+- `value_int64` (List of Number) list of size <=1 consisting of an integer value.
+- `value_string` (List of String) list of size <=1 consisting of a string value.
+- `value_timestamp` (List of String) list of size <=1 consisting of a timestamp value.
 
 
 

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -258,11 +258,13 @@ func dataSourceMonitorV2() *schema.Resource {
 									},
 									"email": { // MonitorV2EmailDestinationInput
 										Type:     schema.TypeList,
+										Optional: true,
 										Computed: true,
 										Elem:     monitorV2EmailActionDatasource(),
 									},
 									"webhook": { // MonitorV2WebhookDestinationInput
 										Type:     schema.TypeList,
+										Optional: true,
 										Computed: true,
 										Elem:     monitorV2WebhookActionDatasource(),
 									},
@@ -282,23 +284,27 @@ func dataSourceMonitorV2() *schema.Resource {
 						"conditions": { // MonitorV2ComparisonExpression
 							Type:        schema.TypeList,
 							Computed:    true,
+							Optional:    true,
 							Description: descriptions.Get("monitorv2", "schema", "actions", "conditions", "description"),
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"compare_terms": { // [MonitorV2ComparisonTerm!]
 										Type:     schema.TypeList,
 										Computed: true,
+										Optional: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"comparison": { // [MonitorV2Comparison!]!
 													Type:        schema.TypeList,
 													Computed:    true,
+													Optional:    true,
 													Elem:        monitorV2ComparisonDatasource(),
 													Description: descriptions.Get("monitorv2", "schema", "actions", "conditions", "compare_terms", "comparison"),
 												},
 												"column": { // [MonitorV2Column!]!
 													Type:        schema.TypeList,
 													Computed:    true,
+													Optional:    true,
 													Elem:        monitorV2ColumnDatasource(),
 													Description: descriptions.Get("monitorv2", "schema", "actions", "conditions", "compare_terms", "column"),
 												},


### PR DESCRIPTION
Currently, when exporting a TypeList with Elem: schema.Resource, it gets exported as a list of objects (using square brackets) instead of blocks, which is invalid.

Turns out the `terraform show` command used by our export implementation will have this behavior when `Computed: true` is used without either `Optional: true` or `Required: true`. This is likely because the block format only makes sense when it's possible to use the field as an input. For purely computed fields, we would only reference the data and the list format is equivalent in that case.

Added `Optional:true` to all relevant fields, though it is not actually valid to provide these fields as input when querying and will be ignored.