### PR TITLE
fix: update tests

### DIFF
--- a/observe/resource_rbac_group_member.go
+++ b/observe/resource_rbac_group_member.go
@@ -35,6 +35,7 @@ func resourceRbacGroupmember() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"member": {
 				Type:     schema.TypeList,

--- a/observe/resource_rbac_group_member_test.go
+++ b/observe/resource_rbac_group_member_test.go
@@ -8,42 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccObserveRbacGroupmemberWithGroupCreate(t *testing.T) {
-	randomPrefix := acctest.RandomWithPrefix("tf")
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(configPreamble+`
-				data "observe_rbac_group" "reader" {
-				  name      = "%[1]s"
-				}
-
-				resource "observe_rbac_group" "example" {
-				  name      = "%[2]s"
-				}
-
-				resource "observe_rbac_group_member" "example" {
-				  group = observe_rbac_group.example.oid
-				  description = "example"
-				  member {
-				    group = data.observe_rbac_group.reader.oid
-				  }
-				}
-				`, defaultRbacGroupReaderName, randomPrefix),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("observe_rbac_group_member.example", "group"),
-					resource.TestCheckResourceAttr("observe_rbac_group_member.example", "description", "example"),
-					resource.TestCheckResourceAttr("observe_rbac_group_member.example", "member.#", "1"),
-					resource.TestCheckResourceAttrSet("observe_rbac_group_member.example", "member.0.group"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccObserveRbacGroupmemberWithUserCreate(t *testing.T) {
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
@@ -63,7 +27,6 @@ func TestAccObserveRbacGroupmemberWithUserCreate(t *testing.T) {
 
 				resource "observe_rbac_group_member" "example" {
 				  group = observe_rbac_group.example.oid
-				  description = "example"
 				  member {
 				    user= data.observe_user.system.oid
 				  }
@@ -71,7 +34,6 @@ func TestAccObserveRbacGroupmemberWithUserCreate(t *testing.T) {
 				`, systemUser(), randomPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("observe_rbac_group_member.example", "group"),
-					resource.TestCheckResourceAttr("observe_rbac_group_member.example", "description", "example"),
 					resource.TestCheckResourceAttr("observe_rbac_group_member.example", "member.#", "1"),
 					resource.TestCheckResourceAttrSet("observe_rbac_group_member.example", "member.0.user"),
 				),

--- a/observe/resource_source_dataset_test.go
+++ b/observe/resource_source_dataset_test.go
@@ -60,7 +60,7 @@ func TestAccObserveSourceDatasetResource(t *testing.T) {
 					}
 					field {
 						name = "TAG"
-						type = "any"
+						type = "variant"
 						sql_type = "VARIANT"
 					}
 				}`, randomPrefix, randomTablePrefix, randomTablePrefix),
@@ -127,7 +127,7 @@ func TestAccObserveSourceDatasetResource(t *testing.T) {
 					}
 					field {
 						name = "TAG"
-						type = "any"
+						type = "variant"
 						sql_type = "VARIANT"
 					}
 					field {
@@ -227,7 +227,7 @@ func TestInvalidValidFromFieldErrors(t *testing.T) {
 					}
 					field {
 						name = "TAG"
-						type = "any"
+						type = "variant"
 						sql_type = "VARIANT"
 					}
 				}`, randomPrefix, randomTablePrefix, randomTablePrefix),


### PR DESCRIPTION
- In RBAC v2, groups can no longer be members of other groups
- In RBAC v2, the description for rbac_group_member is ignored
- Source dataset field type "any" is now called "variant"