### PR TITLE
fix: always diff suppress groupmember description

### DIFF
--- a/observe/diff.go
+++ b/observe/diff.go
@@ -11,3 +11,7 @@ func diffSuppressDuration(k, old, new string, d *schema.ResourceData) bool {
 	n, _ := time.ParseDuration(new)
 	return o == n
 }
+
+func diffSuppressAlways(_, _, _ string, _ *schema.ResourceData) bool {
+	return true
+}

--- a/observe/resource_rbac_group_member.go
+++ b/observe/resource_rbac_group_member.go
@@ -33,9 +33,9 @@ func resourceRbacGroupmember() *schema.Resource {
 				ValidateDiagFunc: validateOID(oid.TypeRbacGroup),
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressAlways,
 			},
 			"member": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
With RBAC v2, the groupmember description field is ignored and we don't want unnecessary diffs. In RBAC v1, the description field is saved but not actually used or displayed anywhere, so it's safe to suppress.