### PR TITLE
Fix two bugs in the resource_monitor_v2

### DIFF
--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -81,7 +81,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
+- `value_duration` (List of String) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -135,7 +135,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
+- `value_duration` (List of String) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -198,7 +198,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
+- `value_duration` (List of String) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -230,7 +230,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
+- `value_duration` (List of String) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -284,7 +284,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
+- `value_duration` (List of String) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -429,7 +429,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
+- `value_duration` (List of String) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -81,7 +81,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of String) list of size <=1 consisting of a duration value.
+- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -135,7 +135,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of String) list of size <=1 consisting of a duration value.
+- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -198,7 +198,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of String) list of size <=1 consisting of a duration value.
+- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -230,7 +230,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of String) list of size <=1 consisting of a duration value.
+- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -284,7 +284,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of String) list of size <=1 consisting of a duration value.
+- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.
@@ -429,7 +429,7 @@ Required:
 Optional:
 
 - `value_bool` (List of Boolean) list of size <=1 consisting of a boolean value.
-- `value_duration` (List of String) list of size <=1 consisting of a duration value.
+- `value_duration` (List of Number) list of size <=1 consisting of a duration value.
 - `value_float64` (List of Number) list of size <=1 consisting of a float value.
 - `value_int64` (List of Number) list of size <=1 consisting of an integer value.
 - `value_string` (List of String) list of size <=1 consisting of a string value.

--- a/observe/resource_http_post_test.go
+++ b/observe/resource_http_post_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccObserveHTTPPostCreate(t *testing.T) {
+	t.Skip("OB-40979")
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
 	resource.Test(t, resource.TestCase{
@@ -67,6 +68,7 @@ func TestAccObserveHTTPPostCreate(t *testing.T) {
 }
 
 func TestAccObserveHTTPPostCreateContentType(t *testing.T) {
+	t.Skip("OB-40979")
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -399,14 +399,10 @@ func monitorV2ComparisonResource() *schema.Resource {
 				Description: descriptions.Get("monitorv2", "schema", "comparison", "value_string"),
 			},
 			"value_duration": { // Integer
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Schema{
-					Type:             schema.TypeInt,
-					ValidateDiagFunc: validateTimeDuration,
-					DiffSuppressFunc: diffSuppressTimeDurationZeroDistinctFromEmpty,
-				},
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
 				Description: descriptions.Get("monitorv2", "schema", "comparison", "value_duration"),
 			},
 			"value_timestamp": { // Time

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -193,7 +193,7 @@ func resourceMonitorV2() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: validateTimeDuration,
-				DiffSuppressFunc: diffSuppressDuration, // Since this is optional:true and nullable:false in GraphQL, null and "0" are the same
+				DiffSuppressFunc: diffSuppressDuration, // Since this is optional:true and nullable:false in gmodelgen, null and "0" are the same
 				Description:      descriptions.Get("monitorv2", "schema", "lookback_time"),
 			},
 			"data_stabilization_delay": { // Duration

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -193,7 +193,7 @@ func resourceMonitorV2() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: validateTimeDuration,
-				DiffSuppressFunc: diffSuppressTimeDurationZeroDistinctFromEmpty,
+				DiffSuppressFunc: diffSuppressDuration, // Since this is optional:true and nullable:false in GraphQL, null and "0" are the same
 				Description:      descriptions.Get("monitorv2", "schema", "lookback_time"),
 			},
 			"data_stabilization_delay": { // Duration
@@ -398,12 +398,12 @@ func monitorV2ComparisonResource() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: descriptions.Get("monitorv2", "schema", "comparison", "value_string"),
 			},
-			"value_duration": { // Int64
+			"value_duration": { // String
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Schema{
-					Type:             schema.TypeInt,
+					Type:             schema.TypeString,
 					ValidateDiagFunc: validateTimeDuration,
 					DiffSuppressFunc: diffSuppressTimeDurationZeroDistinctFromEmpty,
 				},

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -398,12 +398,12 @@ func monitorV2ComparisonResource() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: descriptions.Get("monitorv2", "schema", "comparison", "value_string"),
 			},
-			"value_duration": { // String
+			"value_duration": { // Integer
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Schema{
-					Type:             schema.TypeString,
+					Type:             schema.TypeInt,
 					ValidateDiagFunc: validateTimeDuration,
 					DiffSuppressFunc: diffSuppressTimeDurationZeroDistinctFromEmpty,
 				},

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -226,7 +226,7 @@ func TestAccObserveMonitorV2Promote(t *testing.T) {
 								compare_columns {
 									compare_values {
 										compare_fn = "greater"
-										value_duration = ["1m"]
+										value_duration = [60000000000]
 									}
 									column {
 										column_path {

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -226,7 +226,7 @@ func TestAccObserveMonitorV2Promote(t *testing.T) {
 								compare_columns {
 									compare_values {
 										compare_fn = "greater"
-										value_duration = [60000000000]
+										value_duration = ["1m"]
 									}
 									column {
 										column_path {
@@ -261,7 +261,7 @@ func TestAccObserveMonitorV2Promote(t *testing.T) {
 				`, randomPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "lookback_time", "0s"),
-					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.compare_values.0.value_duration.0", "60000000000"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.compare_values.0.value_duration.0", "1m0s"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.column.0.column_path.0.name", "temp_duration"),
 				),
 			},

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -261,7 +261,7 @@ func TestAccObserveMonitorV2Promote(t *testing.T) {
 				`, randomPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "lookback_time", "0s"),
-					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.compare_values.0.value_duration.0", "1m"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.compare_values.0.value_duration.0", "1m0s"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.column.0.column_path.0.name", "temp_duration"),
 				),
 			},

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -145,6 +145,7 @@ func TestAccObserveMonitorV2Promote(t *testing.T) {
 							pipeline = <<-EOF
 								colmake temp_number:14
 								colmake temp_string:"test"
+								colmake temp_duration:5m
 							EOF
 						}
 						rules {
@@ -200,6 +201,68 @@ func TestAccObserveMonitorV2Promote(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.1.promote.0.compare_columns.0.compare_values.0.value_string.0", "test"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.1.promote.0.compare_columns.0.column.0.column_path.0.name", "temp_string"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "scheduling.0.transform.0.freshness_goal", "15m0s"),
+				),
+			},
+			// now test update
+			{
+				Config: fmt.Sprintf(monitorV2ConfigPreamble+`
+					resource "observe_monitor_v2" "first" {
+						workspace = data.observe_workspace.default.oid
+						rule_kind = "promote"
+						name = "%[1]s"
+						inputs = {
+							"test" = observe_datastream.test.dataset
+						}
+						stage {
+							pipeline = <<-EOF
+								colmake temp_number:14
+								colmake temp_string:"test"
+								colmake temp_duration:5m
+							EOF
+						}
+						rules {
+							level = "informational"
+							promote {
+								compare_columns {
+									compare_values {
+										compare_fn = "greater"
+										value_duration = ["1m"]
+									}
+									column {
+										column_path {
+											name = "temp_duration"
+										}
+									}
+								}
+							}
+						}
+						rules {
+							level = "error"
+							promote {
+								compare_columns {
+									compare_values {
+										compare_fn = "not_contains"
+										value_string = ["test"]
+									}
+									column {
+										column_path {
+											name = "temp_string"
+										}
+									}
+								}
+							}
+						}
+						scheduling {
+							transform {
+								freshness_goal= "15m"
+							}
+						}
+					}
+				`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "lookback_time", "0s"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.compare_values.0.value_duration.0", "1m"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.column.0.column_path.0.name", "temp_duration"),
 				),
 			},
 		},

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -261,7 +261,7 @@ func TestAccObserveMonitorV2Promote(t *testing.T) {
 				`, randomPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "lookback_time", "0s"),
-					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.compare_values.0.value_duration.0", "1m0s"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.compare_values.0.value_duration.0", "60000000000"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.promote.0.compare_columns.0.column.0.column_path.0.name", "temp_duration"),
 				),
 			},


### PR DESCRIPTION
1. DiffSuppressFunc set to diffSuppressTimeDuration for lookback_time. This is to ensure a null lookback_time doesn't trigger the resource to update (check: OB-40067).

2. value_duration Type set to schema.TypeString as the validateTimeDuration would panic when casting the type integer to a string.