### PR TITLE
test: skip rbac v1 statement tests

### DIFF
--- a/observe/resource_rbac_statement_test.go
+++ b/observe/resource_rbac_statement_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccObserveRbacStatementWithGroupCreate(t *testing.T) {
+	t.Skipf("skipping, cannot create rbac v1 statements after rbac v2 is enabled, to be removed")
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
 	resource.Test(t, resource.TestCase{
@@ -105,6 +106,7 @@ func TestAccObserveRbacStatementWithGroupCreate(t *testing.T) {
 }
 
 func TestAccObserveRbacStatementWithUserCreate(t *testing.T) {
+	t.Skipf("skipping, cannot create rbac v1 statements after rbac v2 is enabled, to be removed")
 	randomPrefix := acctest.RandomWithPrefix("tf")
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -173,6 +175,7 @@ func TestAccObserveRbacStatementWithUserCreate(t *testing.T) {
 }
 
 func TestAccObserveRbacStatementAllCreate(t *testing.T) {
+	t.Skipf("skipping, cannot create rbac v1 statements after rbac v2 is enabled, to be removed")
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
 	resource.Test(t, resource.TestCase{
@@ -207,6 +210,7 @@ func TestAccObserveRbacStatementAllCreate(t *testing.T) {
 }
 
 func TestAccObserveRbacStatementTypeCreate(t *testing.T) {
+	t.Skipf("skipping, cannot create rbac v1 statements after rbac v2 is enabled, to be removed")
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
The test tenant has RBAC v2 enabled and creating new v1 statements is no longer supported. The v1 tests can be removed, but just skipping them for now until v1 is fully deprecated.