### PR TITLE
feat: Add IsNull and IsNotNull for MonitorV2 comparisons

### DIFF
--- a/client/internal/meta/schema/monitorv2.graphql
+++ b/client/internal/meta/schema/monitorv2.graphql
@@ -75,6 +75,8 @@ enum MonitorV2ComparisonFunction @goModel(model: "observe/meta/metatypes.Monitor
   Equal
   Greater
   GreaterOrEqual
+  IsNotNull
+  IsNull
   Less
   LessOrEqual
   NotContains

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -4888,6 +4888,8 @@ const (
 	MonitorV2ComparisonFunctionEqual          MonitorV2ComparisonFunction = "Equal"
 	MonitorV2ComparisonFunctionGreater        MonitorV2ComparisonFunction = "Greater"
 	MonitorV2ComparisonFunctionGreaterorequal MonitorV2ComparisonFunction = "GreaterOrEqual"
+	MonitorV2ComparisonFunctionIsnotnull      MonitorV2ComparisonFunction = "IsNotNull"
+	MonitorV2ComparisonFunctionIsnull         MonitorV2ComparisonFunction = "IsNull"
 	MonitorV2ComparisonFunctionLess           MonitorV2ComparisonFunction = "Less"
 	MonitorV2ComparisonFunctionLessorequal    MonitorV2ComparisonFunction = "LessOrEqual"
 	MonitorV2ComparisonFunctionNotcontains    MonitorV2ComparisonFunction = "NotContains"


### PR DESCRIPTION
Nothing drastic here. It already uses the toSnake() to properly format/unformat. Just bringing over the new enums.