### PR TITLE
docs: update deprecation messages

### DIFF
--- a/docs/data-sources/board.md
+++ b/docs/data-sources/board.md
@@ -3,10 +3,13 @@
 page_title: "observe_board Data Source - terraform-provider-observe"
 subcategory: ""
 description: |-
+  Deprecated. Use observe_dashboard instead.
   Fetches data for an existing Observe board.
 ---
 
 # observe_board (Data Source)
+
+Deprecated. Use `observe_dashboard` instead.
 
 Fetches data for an existing Observe board.
 

--- a/docs/data-sources/dataset.md
+++ b/docs/data-sources/dataset.md
@@ -39,7 +39,7 @@ One of `name` or `id` must be set. If `name` is provided, `workspace` must be se
 - `acceleration_disabled` (Boolean)
 - `acceleration_disabled_source` (String)
 - `correlation_tag` (Block List) Correlation tags associated with this dataset. (see [below for nested schema](#nestedblock--correlation_tag))
-- `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI
+- `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI. Not intended to be configured by hand, please use export functionality.
 - `description` (String) Dataset description.
 - `freshness` (String) Target freshness for results. Tighten the freshness to increase the
 frequency with which queries are run, which incurs higher transform costs.

--- a/docs/resources/board.md
+++ b/docs/resources/board.md
@@ -3,9 +3,12 @@
 page_title: "observe_board Resource - terraform-provider-observe"
 subcategory: ""
 description: |-
+  Deprecated. Use observe_dashboard instead.
   Manages an Observe board.
 ---
 # observe_board
+
+Deprecated. Use `observe_dashboard` instead.
 
 Manages an Observe board.
 

--- a/docs/resources/channel.md
+++ b/docs/resources/channel.md
@@ -3,9 +3,12 @@
 page_title: "observe_channel Resource - terraform-provider-observe"
 subcategory: ""
 description: |-
+  Deprecated. Use observe_monitor_action_attachment instead.
   Manages a channel, which specifies a set of monitors for which notifications will be delivered.
 ---
 # observe_channel
+
+Deprecated. Use `observe_monitor_action_attachment` instead.
 
 Manages a channel, which specifies a set of monitors for which notifications will be delivered.
 

--- a/docs/resources/channel_action.md
+++ b/docs/resources/channel_action.md
@@ -3,9 +3,12 @@
 page_title: "observe_channel_action Resource - terraform-provider-observe"
 subcategory: ""
 description: |-
+  Deprecated. Use observe_monitor_action instead.
   Manages a channel action, which adds a notification template to the specified channel. Channel actions are used to configure delivery for monitor alerts.
 ---
 # observe_channel_action
+
+Deprecated. Use `observe_monitor_action` instead.
 
 Manages a channel action, which adds a notification template to the specified channel. Channel actions are used to configure delivery for monitor alerts.
 

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -51,7 +51,7 @@ its predecessor. (see [below for nested schema](#nestedblock--stage))
 
 - `acceleration_disabled` (Boolean) Disables periodic materialization of the dataset
 - `acceleration_disabled_source` (String) Source of disabled materialization
-- `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI
+- `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI. Not intended to be configured by hand, please use export functionality.
 - `description` (String) Dataset description.
 - `freshness` (String) Target freshness for results. Tighten the freshness to increase the
 frequency with which queries are run, which incurs higher transform costs.

--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -3,18 +3,15 @@
 page_title: "observe_grant Resource - terraform-provider-observe"
 subcategory: ""
 description: |-
-  NOTE: This feature is still under development. It is not meant for customer use yet.
   Manages an Observe grant. Grants allow configuring permissions for users and groups by
-  assigning roles. A grant may also optionally be qualified by an object id. Replaces
-  rbac_statement. Reach out to Observe to enable this feature.
+  assigning roles. A grant may also optionally be qualified by an object id. Also see
+  observe_resource_grants for an authoritative way to manage grants for a resource.
 ---
 # observe_grant
 
-NOTE: This feature is still under development. It is not meant for customer use yet.
-
 Manages an Observe grant. Grants allow configuring permissions for users and groups by
-assigning roles. A grant may also optionally be qualified by an object id. Replaces
-rbac_statement. Reach out to Observe to enable this feature.
+assigning roles. A grant may also optionally be qualified by an object id. Also see
+`observe_resource_grants` for an authoritative way to manage grants for a resource.
 ## Example Usage
 ```terraform
 data "observe_workspace" "default" {

--- a/docs/resources/rbac_statement.md
+++ b/docs/resources/rbac_statement.md
@@ -3,9 +3,12 @@
 page_title: "observe_rbac_statement Resource - terraform-provider-observe"
 subcategory: ""
 description: |-
+  Deprecated. Only for use with RBAC v1. For v2, use observe_grant.
   Manages a RBAC Statement.
 ---
 # observe_rbac_statement
+
+Deprecated. Only for use with RBAC v1. For v2, use `observe_grant`.
 
 Manages a RBAC Statement.
 ## Example Usage

--- a/docs/resources/resource_grants.md
+++ b/docs/resources/resource_grants.md
@@ -3,15 +3,12 @@
 page_title: "observe_resource_grants Resource - terraform-provider-observe"
 subcategory: ""
 description: |-
-  NOTE: This feature is still under development. It is not meant for customer use yet.
   Authoritative. Should not be used together with any observe_grants targeting the
   same resource as they will conflict.
   Manages the complete set of grants for a given resource, replacing any existing ones.
   If no grants are specified, only admins will have access.
 ---
 # observe_resource_grants
-
-NOTE: This feature is still under development. It is not meant for customer use yet.
 
 Authoritative. Should not be used together with any `observe_grant`s targeting the
 same resource as they will conflict.

--- a/observe/data_source_board.go
+++ b/observe/data_source_board.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceBoard() *schema.Resource {
 	return &schema.Resource{
-		Description:        "Fetches data for an existing Observe board.",
+		Description:        "Deprecated. Use `observe_dashboard` instead.\n\nFetches data for an existing Observe board.",
 		DeprecationMessage: "Boards have been deprecated in favor of dashboards.",
 
 		ReadContext: dataSourceBoardRead,

--- a/observe/descriptions/dataset.yaml
+++ b/observe/descriptions/dataset.yaml
@@ -16,7 +16,7 @@ schema:
   acceleration_disabled_source: |
     Source of disabled materialization
   data_table_view_state: |
-    JSON representation of state used for dataset formatting in the UI
+    JSON representation of state used for dataset formatting in the UI. Not intended to be configured by hand, please use export functionality.
   correlation_tag:
     description: |
       Correlation tags associated with this dataset.

--- a/observe/descriptions/grant.yaml
+++ b/observe/descriptions/grant.yaml
@@ -1,9 +1,7 @@
 description: |
-  NOTE: This feature is still under development. It is not meant for customer use yet.
-
   Manages an Observe grant. Grants allow configuring permissions for users and groups by
-  assigning roles. A grant may also optionally be qualified by an object id. Replaces
-  rbac_statement. Reach out to Observe to enable this feature.
+  assigning roles. A grant may also optionally be qualified by an object id. Also see
+  `observe_resource_grants` for an authoritative way to manage grants for a resource.
 
 schema:
   subject: |

--- a/observe/descriptions/resource_grants.yaml
+++ b/observe/descriptions/resource_grants.yaml
@@ -1,6 +1,4 @@
 description: |
-  NOTE: This feature is still under development. It is not meant for customer use yet.
-  
   Authoritative. Should not be used together with any `observe_grant`s targeting the
   same resource as they will conflict.
   

--- a/observe/resource_board.go
+++ b/observe/resource_board.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	schemaBoardDescription        = "Manages an Observe board."
 	schemaBoardOIDDescription     = "Observe ID of Board."
 	schemaBoardDatasetDescription = "OID of Dataset for which board is defined."
 	schemaBoardTypeDescription    = "Type of board."
@@ -23,7 +24,7 @@ const (
 
 func resourceBoard() *schema.Resource {
 	return &schema.Resource{
-		Description:        "Manages an Observe board.",
+		Description:        "Deprecated. Use `observe_dashboard` instead.\n\nManages an Observe board.",
 		DeprecationMessage: "Boards have been deprecated in favor of dashboards, which can define their own stages for futher processing of datasets.",
 		CreateContext:      resourceBoardCreate,
 		ReadContext:        resourceBoardRead,

--- a/observe/resource_channel.go
+++ b/observe/resource_channel.go
@@ -13,7 +13,7 @@ import (
 
 func resourceChannel() *schema.Resource {
 	return &schema.Resource{
-		Description:        "Manages a channel, which specifies a set of monitors for which notifications will be delivered.",
+		Description:        "Deprecated. Use `observe_monitor_action_attachment` instead.\n\nManages a channel, which specifies a set of monitors for which notifications will be delivered.",
 		DeprecationMessage: "Channels are deprecated in favor of attaching Monitor Actions to Monitors. See `observe_monitor_action_attachment`.",
 		CreateContext:      resourceChannelCreate,
 		ReadContext:        resourceChannelRead,

--- a/observe/resource_channel_action.go
+++ b/observe/resource_channel_action.go
@@ -14,7 +14,7 @@ import (
 
 func resourceChannelAction() *schema.Resource {
 	return &schema.Resource{
-		Description:        "Manages a channel action, which adds a notification template to the specified channel. Channel actions are used to configure delivery for monitor alerts.",
+		Description:        "Deprecated. Use `observe_monitor_action` instead.\n\nManages a channel action, which adds a notification template to the specified channel. Channel actions are used to configure delivery for monitor alerts.",
 		DeprecationMessage: "Channel Actions are deprecated in favor of Monitor Actions.",
 		CreateContext:      resourceChannelActionCreate,
 		ReadContext:        resourceChannelActionRead,

--- a/observe/resource_rbac_statement.go
+++ b/observe/resource_rbac_statement.go
@@ -36,11 +36,12 @@ var rbacStatementObjectTypes = []string{
 
 func resourceRbacStatement() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Manages a RBAC Statement.",
-		CreateContext: resourceRbacStatementCreate,
-		UpdateContext: resourceRbacStatementUpdate,
-		ReadContext:   resourceRbacStatementRead,
-		DeleteContext: resourceRbacStatementDelete,
+		Description:        "Deprecated. Only for use with RBAC v1. For v2, use `observe_grant`.\n\nManages a RBAC Statement.",
+		DeprecationMessage: "RBAC Statements are deprecated and only for use with RBAC v1. For v2, see `observe_grant`.",
+		CreateContext:      resourceRbacStatementCreate,
+		UpdateContext:      resourceRbacStatementUpdate,
+		ReadContext:        resourceRbacStatementRead,
+		DeleteContext:      resourceRbacStatementDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},


### PR DESCRIPTION
- Specifying a DeprecationMessage doesn't update the docs due to https://github.com/hashicorp/terraform-plugin-docs/issues/10, manually updated the description for all deprecated resources
- Deprecated observe_rbac_statement in favor of observe_grant for use with RBAC v2
- Removed "under development" note for `observe_grant` and `observe_resource_grants`
- Clarified that `dataTableViewState` is not intended to be configured by hand