### PR TITLE
fix: keep original behavior for skip_rematerialization, introduce new must_skip_rematerialization

### DIFF
--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -61,10 +61,9 @@ frequency with which queries are run, which incurs higher transform costs.
 this value will reduce the preference for using this dataset when computing
 paths between two datasets.
 - `rematerialization_mode` (String) Specifies rematerialization mode when updating a dataset. Options include
-"rematerialize", "skip_rematerialization", and "try_skip_rematerialization" - if no option is used, "rematerialize"
-is used by default. "skip_rematerialization" will skip rematerialization if certain conditions
-are met, will rematerialize otherwise. "try_skip_rematerialization" is similar to "skip_rematerialization" but will
-rematerialize if rematerialization cannot be skipped.
+"rematerialize" (default), "skip_rematerialization", and "must_skip_rematerialization".
+"skip_rematerialization" will skip rematerialization if certain conditions are met, will rematerialize otherwise.
+"must_skip_rematerialization" will never rematerialize, update will fail if skipping rematerialization is not possible.
 
 ### Read-Only
 

--- a/observe/descriptions/dataset.yaml
+++ b/observe/descriptions/dataset.yaml
@@ -22,7 +22,6 @@ schema:
       Correlation tags associated with this dataset.
   rematerialization_mode: |
     Specifies rematerialization mode when updating a dataset. Options include
-    "rematerialize", "skip_rematerialization", and "try_skip_rematerialization" - if no option is used, "rematerialize"
-    is used by default. "skip_rematerialization" will skip rematerialization if certain conditions
-    are met, will rematerialize otherwise. "try_skip_rematerialization" is similar to "skip_rematerialization" but will
-    rematerialize if rematerialization cannot be skipped.
+    "rematerialize" (default), "skip_rematerialization", and "must_skip_rematerialization".
+    "skip_rematerialization" will skip rematerialization if certain conditions are met, will rematerialize otherwise.
+    "must_skip_rematerialization" will never rematerialize, update will fail if skipping rematerialization is not possible.

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -570,7 +570,7 @@ func TestAccObserveDatasetEditForward(t *testing.T) {
 					  "test" = observe_datastream.test.dataset
 					}
 
-					rematerialization_mode = "skip_rematerialization"
+					rematerialization_mode = "must_skip_rematerialization"
 					stage {
 					  	pipeline = <<-EOF
 							make_col x: 2
@@ -585,7 +585,7 @@ func TestAccObserveDatasetEditForward(t *testing.T) {
 					resource.TestCheckNoResourceAttr("observe_dataset.first", "path_cost"),
 					resource.TestCheckNoResourceAttr("observe_dataset.first", "on_demand_materialization_length"),
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.input", ""),
-					resource.TestCheckResourceAttr("observe_dataset.first", "rematerialization_mode", "skip_rematerialization"),
+					resource.TestCheckResourceAttr("observe_dataset.first", "rematerialization_mode", "must_skip_rematerialization"),
 				),
 			},
 		},
@@ -637,7 +637,7 @@ func TestAccObserveDatasetEditForwardDryRun(t *testing.T) {
 					  "test" = observe_datastream.test.dataset
 					}
 
-					rematerialization_mode = "skip_rematerialization"
+					rematerialization_mode = "must_skip_rematerialization"
 					stage {
 					  	pipeline = <<-EOF
 							make_col x: 1, y: 2
@@ -651,7 +651,7 @@ func TestAccObserveDatasetEditForwardDryRun(t *testing.T) {
 }
 
 // Test that a change rematerializes when incompatible with edit-forward
-func TestAccObserveDatasetEditForwardTrySkip(t *testing.T) {
+func TestAccObserveDatasetEditForwardNoDryRun(t *testing.T) {
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -695,7 +695,7 @@ func TestAccObserveDatasetEditForwardTrySkip(t *testing.T) {
 					  "test" = observe_datastream.test.dataset
 					}
 
-					rematerialization_mode = "try_skip_rematerialization"
+					rematerialization_mode = "skip_rematerialization"
 					stage {
 					  	pipeline = <<-EOF
 							make_col x: 1, y: 2
@@ -710,7 +710,7 @@ func TestAccObserveDatasetEditForwardTrySkip(t *testing.T) {
 					resource.TestCheckNoResourceAttr("observe_dataset.first", "path_cost"),
 					resource.TestCheckNoResourceAttr("observe_dataset.first", "on_demand_materialization_length"),
 					resource.TestCheckResourceAttr("observe_dataset.first", "stage.0.input", ""),
-					resource.TestCheckResourceAttr("observe_dataset.first", "rematerialization_mode", "try_skip_rematerialization"),
+					resource.TestCheckResourceAttr("observe_dataset.first", "rematerialization_mode", "skip_rematerialization"),
 				),
 			},
 		},


### PR DESCRIPTION
Changing the behavior of "skip_rematerialization" to fail if skipping rematerialization is not possible may cause issues with apps in certain rare cases. Changed it back to the original behavior, and introduced new option "must_skip_rematerialization" for new behavior.