### PR TITLE
test: add random prefix to rbac group in layered setting test

### DIFF
--- a/observe/resource_layered_setting_record_test.go
+++ b/observe/resource_layered_setting_record_test.go
@@ -41,7 +41,7 @@ func TestAccLayeredSettingRecord(t *testing.T) {
 				}
 				
 				resource "observe_rbac_group" "limit_power" {
-					name = "limit_power"
+					name = "$[1]s-limit_power"
 				}
 				resource "observe_layered_setting_record" "group_int64" {
 					workspace   = data.observe_workspace.default.oid


### PR DESCRIPTION
to avoid conflicting with concurrently running tests (can't have 2 rbac groups with the same name)