### PR TITLE
fix: re-create links if not found during update

### DIFF
--- a/observe/resource_link.go
+++ b/observe/resource_link.go
@@ -118,6 +118,13 @@ func resourceLinkUpdate(ctx context.Context, data *schema.ResourceData, meta int
 
 	_, err := client.UpdateForeignKey(ctx, data.Id(), config)
 	if err != nil {
+		if gql.HasErrorCode(err, gql.ErrNotFound) {
+			diags = resourceLinkCreate(ctx, data, meta)
+			if diags.HasError() {
+				return diags
+			}
+			return nil
+		}
 		return diag.Errorf("failed to update foreign key: %s", err.Error())
 	}
 


### PR DESCRIPTION
Normally, when running terraform apply, it'll refresh the state first at which point if a link no longer exists, terraform will plan to re-create it automatically. However, in the case where the link does exist when refreshing the state, but then is deleted during the apply (e.g. due to the source dataset being updated), the update to the link then fails. We now will re-create the link if the update fails due to link not found.