### PR TITLE
feat: support generating bindings for monitors

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -618,7 +618,7 @@ func (c *Client) LookupMonitorV2(ctx context.Context, workspaceId *string, nameE
 	return c.Meta.LookupMonitorV2(ctx, workspaceId, nameExact)
 }
 
-func (c *Client) SearchMonitorV2Action(ctx context.Context, workspaceId *string, nameExact *string) (*meta.MonitorV2Action, error) {
+func (c *Client) SearchMonitorV2Action(ctx context.Context, workspaceId *string, nameExact *string) ([]meta.MonitorV2Action, error) {
 	return c.Meta.SearchMonitorV2Action(ctx, workspaceId, nameExact)
 }
 

--- a/client/binding/binding.go
+++ b/client/binding/binding.go
@@ -75,6 +75,14 @@ func NewResourceCache(ctx context.Context, kinds KindSet, client *observe.Client
 			for _, user := range users {
 				cache.addEntry(KindUser, user.Label, user.Id.String(), true, &disambiguator, existingResourceNames)
 			}
+		case KindMonitorV2Action:
+			actions, err := client.SearchMonitorV2Action(ctx, &cache.workspaceOid.Id, nil)
+			if err != nil {
+				return cache, err
+			}
+			for _, action := range actions {
+				cache.addEntry(KindMonitorV2Action, action.Name, action.Id, true, &disambiguator, existingResourceNames)
+			}
 		}
 	}
 	return cache, nil
@@ -264,6 +272,8 @@ func resolveOidToKinds(oidObj *oid.OID) []Kind {
 		return []Kind{KindWorkspace}
 	case oid.TypeUser:
 		return []Kind{KindUser}
+	case oid.TypeMonitorV2Action:
+		return []Kind{KindMonitorV2Action}
 	default:
 		return []Kind{}
 	}

--- a/client/binding/binding.go
+++ b/client/binding/binding.go
@@ -248,6 +248,14 @@ func (g *Generator) GetBindings() (BindingsObject, error) {
 	}, nil
 }
 
+func (g *Generator) GetBindingsJson() ([]byte, error) {
+	bindings, err := g.GetBindings()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(bindings)
+}
+
 // InsertBindingsObject inserts the bindings object into the provided map
 func (g *Generator) InsertBindingsObject(data map[string]interface{}) error {
 	bindingsObject, err := g.GetBindings()

--- a/client/binding/binding.go
+++ b/client/binding/binding.go
@@ -1,3 +1,21 @@
+// Package binding provides utilities for generating bindings for cross-tenant exports.
+// Essentially we want to replace all raw object ids in the resource definition with references
+// instead, created by looking up the objects by name using data sources.
+// Overall, the process works like so:
+//	1. The Observe backend adds a data source with the `export_object_bindings` flag set.
+//  2. When the data source is read, a Generator is created, which iterates through all fields
+//     that could contain ids, and for each id found:
+//      a. The Generator looks up the corresponding resource name and generates a local variable reference
+//      b. The id is replaced with that reference.
+//      c. In addition, the Generator adds a "binding" entry to its internal state. This binding
+//         includes all the information necessary for later generating a data source that fetches
+//         the resource by name, and the local variable definition for the above reference.
+//  3. Finally, we aggregate all the bindings from above and insert it somewhere into the data
+//     source state (typically an internal "_bindings" field).
+//  4. The Observe backend then extracts those bindings from the data source state, and uses
+//     them to generate data sources + locals in addition to the main resource export
+//     (in which the ids have already been replaced with local variable references).
+
 package binding
 
 import (

--- a/client/binding/binding.go
+++ b/client/binding/binding.go
@@ -95,14 +95,14 @@ func (c *ResourceCache) addEntry(kind Kind, label string, id string, addPrefix b
 	} else {
 		tfName = fmt.Sprintf("%s_%s", kind, resourceName)
 	}
-	c.idToLabel[Ref{kind: kind, key: id}] = ResourceCacheEntry{
+	c.idToLabel[Ref{Kind: kind, Key: id}] = ResourceCacheEntry{
 		TfName: tfName,
 		Label:  label,
 	}
 }
 
 func (c *ResourceCache) LookupId(kind Kind, id string) *ResourceCacheEntry {
-	maybeEnt, ok := c.idToLabel[Ref{kind: kind, key: id}]
+	maybeEnt, ok := c.idToLabel[Ref{Kind: kind, Key: id}]
 	if !ok {
 		return nil
 	}
@@ -146,7 +146,7 @@ func (g *Generator) TryBind(kind Kind, id string) string {
 		return id
 	}
 	var e *ResourceCacheEntry
-	if kind == KindWorkspace && id == g.cache.workspaceOid.String() {
+	if kind == KindWorkspace && id == g.cache.workspaceOid.Id {
 		// workspaces are special since there should only be one primary one
 		e = g.cache.workspaceEntry
 	} else {
@@ -159,7 +159,7 @@ func (g *Generator) TryBind(kind Kind, id string) string {
 	// process into local var ref
 	insertPrefix := kind == KindWorkspace
 	terraformLocal := g.fmtTfLocalVar(kind, e, insertPrefix)
-	g.bindings[Ref{kind: kind, key: e.Label}] = Target{
+	g.bindings[Ref{Kind: kind, Key: e.Label}] = Target{
 		TfName:            e.TfName,
 		TfLocalBindingVar: terraformLocal,
 	}
@@ -168,14 +168,23 @@ func (g *Generator) TryBind(kind Kind, id string) string {
 
 func (g *Generator) Generate(data interface{}) {
 	mapOverJsonStringKeys(data, func(key string, value string, jsonMapNode map[string]interface{}) {
-		kinds := resolveKeyToKinds(key)
+		var id string
+		var kinds []Kind
+		if valueOid, err := oid.NewOID(value); err == nil {
+			id = valueOid.Id
+			kinds = resolveOidToKinds(valueOid)
+		} else {
+			id = value
+			kinds = resolveKeyToKinds(key)
+		}
+
 		for _, kind := range kinds {
 			// if not enabled, skip
 			if _, found := g.enabledBindings[kind]; !found {
 				continue
 			}
 			// try bind the name
-			maybeRef := g.TryBind(kind, value)
+			maybeRef := g.TryBind(kind, id)
 			// if lookup succeeded, then the returned value should be a lv ref and not the
 			// input id
 			if maybeRef != value {
@@ -249,6 +258,21 @@ func (g *Generator) fmtTfLocalVar(kind Kind, e *ResourceCacheEntry, insertPrefix
 
 func (g *Generator) fmtTfLocalVarRef(tfLocalVar string) string {
 	return fmt.Sprintf("${local.%s}", tfLocalVar)
+}
+
+func resolveOidToKinds(oidObj *oid.OID) []Kind {
+	switch oidObj.Type {
+	case oid.TypeDataset:
+		return []Kind{KindDataset}
+	case oid.TypeWorksheet:
+		return []Kind{KindWorksheet}
+	case oid.TypeWorkspace:
+		return []Kind{KindWorkspace}
+	case oid.TypeUser:
+		return []Kind{KindUser}
+	default:
+		return []Kind{}
+	}
 }
 
 func resolveKeyToKinds(key string) []Kind {

--- a/client/binding/binding_test.go
+++ b/client/binding/binding_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/observeinc/terraform-provider-observe/client/meta/types"
 	"github.com/observeinc/terraform-provider-observe/client/oid"
 )
 
@@ -70,7 +69,6 @@ func prepareResourceCacheFixture() ResourceCache {
 
 func prepareGeneratorFixture() Generator {
 	return Generator{
-		Enabled:         true,
 		resourceName:    "name",
 		resourceType:    "type",
 		enabledBindings: NewKindSet(KindWorksheet, KindDataset, KindWorkspace, KindUser),
@@ -161,11 +159,12 @@ func TestInsertBindingsObjectJson(t *testing.T) {
 			"workspace_name": "Test wks",
 		},
 	}
-	outputJson, err := g.InsertBindingsObjectJson((*types.JsonObject)(&jsonData))
+	outputJson, err := g.InsertBindingsObjectJson([]byte(jsonData))
 	if err != nil {
 		t.Fatal(err)
 	}
-	output, err := outputJson.Map()
+	var output map[string]interface{}
+	err = json.Unmarshal(outputJson, &output)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/binding/binding_test.go
+++ b/client/binding/binding_test.go
@@ -77,14 +77,14 @@ func prepareGeneratorFixture() Generator {
 	}
 }
 
-func TestTryBind(t *testing.T) {
+func TestTryBindId(t *testing.T) {
 	g := prepareGeneratorFixture()
-	binding := g.TryBind(KindDataset, "41000123")
+	binding, _ := g.TryBindId(KindDataset, "41000123")
 	expectedBinding := "${local.binding__type_name__dataset_dataset_1}"
 	if binding != expectedBinding {
 		t.Fatalf("expected binding %s, got actual binding %s", expectedBinding, binding)
 	}
-	binding = g.TryBind(KindDataset, "not_a_dataset_id")
+	binding, _ = g.TryBindId(KindDataset, "not_a_dataset_id")
 	expectedBinding = "not_a_dataset_id"
 	if binding != expectedBinding {
 		t.Fatalf("Expected no binding '%s', got binding %s", expectedBinding, binding)
@@ -128,7 +128,7 @@ func TestGenerateJson(t *testing.T) {
 
 func TestInsertBindingsObjectJson(t *testing.T) {
 	g := prepareGeneratorFixture()
-	g.TryBind(KindDataset, dataset1Id)
+	g.TryBindId(KindDataset, dataset1Id)
 	// g.bindings[Ref{kind: KindDataset, key: "dataset_1"}] = Target{
 	// 	TfLocalBindingVar: g.fmtTfLocalVar(KindDataset, &, false),
 	// 	TfName:            "dataset_1",
@@ -146,6 +146,7 @@ func TestInsertBindingsObjectJson(t *testing.T) {
 				"dataset:dataset_1": map[string]interface{}{
 					"tf_local_binding_var": "binding__type_name__dataset_dataset_1",
 					"tf_name":              "type_name__dataset_dataset_1",
+					"is_oid":               false,
 				},
 			},
 			"kinds": []interface{}{
@@ -155,6 +156,7 @@ func TestInsertBindingsObjectJson(t *testing.T) {
 			"workspace": map[string]interface{}{
 				"tf_local_binding_var": "binding__type_name__workspace_test_wks",
 				"tf_name":              "workspace_test_wks",
+				"is_oid":               true,
 			},
 			"workspace_name": "Test wks",
 		},

--- a/client/binding/types.go
+++ b/client/binding/types.go
@@ -13,6 +13,8 @@ type Ref struct {
 type Target struct {
 	TfLocalBindingVar string `json:"tf_local_binding_var"`
 	TfName            string `json:"tf_name"`
+	// when generating locals, used to determine whether we should do ${data_source}.id or ${data_source}.oid
+	IsOid bool `json:"is_oid"`
 }
 
 // A binding, i.e. mapping of resource kind + label -> terraform local variable name (which the ids have been replaced with)

--- a/client/binding/types.go
+++ b/client/binding/types.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Ref struct {
-	kind Kind
-	key  string
+	Kind Kind
+	Key  string
 }
 
 type Target struct {
@@ -28,11 +28,12 @@ type BindingsObject struct {
 	WorkspaceName string  `json:"workspace_name"`
 }
 
-const (
-	KindDataset   Kind = "dataset"
-	KindWorksheet Kind = "worksheet"
-	KindWorkspace Kind = "workspace"
-	KindUser      Kind = "user"
+var (
+	// must match the data source names, see DataSourcesMap in observe/provider.go
+	KindDataset   = addKind("dataset")
+	KindWorksheet = addKind("worksheet")
+	KindWorkspace = addKind("workspace")
+	KindUser      = addKind("user")
 )
 
 const (
@@ -41,15 +42,15 @@ const (
 
 var bindingRefParseRegex = regexp.MustCompile(`(.*):(.*)`)
 
-var allKinds = NewKindSet(
-	KindDataset,
-	KindWorksheet,
-	KindWorkspace,
-	KindUser,
-)
+var allKinds = NewKindSet()
+
+func addKind(k Kind) Kind {
+	allKinds[k] = struct{}{}
+	return k
+}
 
 func (r *Ref) String() string {
-	return fmt.Sprintf("%s:%s", r.kind, r.key)
+	return fmt.Sprintf("%s:%s", r.Kind, r.Key)
 }
 
 func (r Ref) MarshalText() (text []byte, err error) {
@@ -74,7 +75,7 @@ func NewRefFromString(s string) (Ref, bool) {
 	if _, ok := allKinds[maybeKind]; !ok {
 		return Ref{}, false
 	}
-	return Ref{kind: maybeKind, key: matches[2]}, true
+	return Ref{Kind: maybeKind, Key: matches[2]}, true
 }
 
 func NewMapping() Mapping {

--- a/client/binding/types.go
+++ b/client/binding/types.go
@@ -41,6 +41,7 @@ var (
 	KindDashboard       = addKind("dashboard")
 	KindMonitorV2       = addKind("monitor_v2")
 	KindMonitorV2Action = addKind("monitor_v2_action")
+	KindMonitor         = addKind("monitor")
 )
 
 const (

--- a/client/binding/types.go
+++ b/client/binding/types.go
@@ -11,9 +11,11 @@ type Ref struct {
 }
 
 type Target struct {
+	// Name of the local variable that will be generated for this target, used in place of the raw ids
 	TfLocalBindingVar string `json:"tf_local_binding_var"`
-	TfName            string `json:"tf_name"`
-	// when generating locals, used to determine whether we should do ${data_source}.id or ${data_source}.oid
+	// Name of the terraform data source that will be generated for this target
+	TfName string `json:"tf_name"`
+	// When generating locals, used to determine whether we should do ${data_source}.id or ${data_source}.oid
 	IsOid bool `json:"is_oid"`
 }
 

--- a/client/binding/types.go
+++ b/client/binding/types.go
@@ -7,7 +7,7 @@ import (
 
 type Ref struct {
 	Kind Kind
-	Key  string
+	Key  string // id when used in ResourceCache, label when used in Mapping
 }
 
 type Target struct {
@@ -15,12 +15,16 @@ type Target struct {
 	TfName            string `json:"tf_name"`
 }
 
+// A binding, i.e. mapping of resource kind + label -> terraform local variable name (which the ids have been replaced with)
 type Mapping map[Ref]Target
 
 type Kind string
 
 type KindSet map[Kind]struct{}
 
+// BindingsObject contains all the information necessary to generate terraform
+// data sources and local variable definitions to support the local variable
+// references replacing the raw ids in the resource data.
 type BindingsObject struct {
 	Mappings      Mapping `json:"mappings"`
 	Kinds         []Kind  `json:"kinds"`
@@ -34,6 +38,7 @@ var (
 	KindWorksheet = addKind("worksheet")
 	KindWorkspace = addKind("workspace")
 	KindUser      = addKind("user")
+	KindDashboard = addKind("dashboard")
 )
 
 const (

--- a/client/binding/types.go
+++ b/client/binding/types.go
@@ -34,11 +34,13 @@ type BindingsObject struct {
 
 var (
 	// must match the data source names, see DataSourcesMap in observe/provider.go
-	KindDataset   = addKind("dataset")
-	KindWorksheet = addKind("worksheet")
-	KindWorkspace = addKind("workspace")
-	KindUser      = addKind("user")
-	KindDashboard = addKind("dashboard")
+	KindDataset         = addKind("dataset")
+	KindWorksheet       = addKind("worksheet")
+	KindWorkspace       = addKind("workspace")
+	KindUser            = addKind("user")
+	KindDashboard       = addKind("dashboard")
+	KindMonitorV2       = addKind("monitor_v2")
+	KindMonitorV2Action = addKind("monitor_v2_action")
 )
 
 const (

--- a/client/binding/types_test.go
+++ b/client/binding/types_test.go
@@ -40,11 +40,11 @@ func TestDeserializeBindingsObject(t *testing.T) {
 		t.Fatalf("Expected %#v, got %#v", expectedKinds, bindingsObj.Kinds)
 	}
 	expectedMappings := Mapping{
-		Ref{kind: KindDataset, key: "Observe Dashboard"}: Target{
+		Ref{Kind: KindDataset, Key: "Observe Dashboard"}: Target{
 			TfLocalBindingVar: "binding__dashboard_bindings_test_dashboard__dataset_observe_dashboard",
 			TfName:            "observe_dashboard",
 		},
-		Ref{kind: KindDataset, key: "usage/Monitor Messages"}: Target{
+		Ref{Kind: KindDataset, Key: "usage/Monitor Messages"}: Target{
 			TfLocalBindingVar: "binding__dashboard_bindings_test_dashboard__dataset_monitor_messages",
 			TfName:            "monitor_messages",
 		},

--- a/client/meta/monitorv2_action.go
+++ b/client/meta/monitorv2_action.go
@@ -38,12 +38,12 @@ func (client *Client) DeleteMonitorV2Action(ctx context.Context, id string) erro
 	return resultStatusError(resp, err)
 }
 
-func (client *Client) SearchMonitorV2Action(ctx context.Context, workspaceId *string, nameExact *string) (*MonitorV2Action, error) {
+func (client *Client) SearchMonitorV2Action(ctx context.Context, workspaceId *string, nameExact *string) ([]MonitorV2Action, error) {
 	resp, err := searchMonitorV2Action(ctx, client.Gql, workspaceId, nil, nameExact, nil)
-	if err != nil || resp == nil || len(resp.MonitorV2Actions.Results) != 1 {
+	if err != nil || resp == nil {
 		return nil, err
 	}
-	return &resp.MonitorV2Actions.Results[0], nil
+	return resp.MonitorV2Actions.Results, nil
 }
 
 func (m *MonitorV2Action) Oid() *oid.OID {

--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -43,6 +43,7 @@ One of `name` or `id` must be set. If `name` is provided, `workspace` must be se
 
 ### Read-Only
 
+- `_bindings` (String) Internal field. Do not use.
 - `comment` (String) A long-form comment describing the content of the monitor.
 - `definition` (String) Monitor definition in JSON format.
 - `description` (String) A brief description of the monitor.

--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -48,6 +48,7 @@ One of `name` or `id` must be set. If `name` is provided, `workspace` must be se
 
 ### Read-Only
 
+- `_bindings` (String) Internal field. Do not use.
 - `actions` (Block List) The list of shared actions to which this monitor is connected. (see [below for nested schema](#nestedblock--actions))
 - `custom_variables` (String)
 - `data_stabilization_delay` (String) expresses the minimum time that should elapse before data is considered "good enough" to evaluate. Choosing a delay really depends on the expectations of latency of data and whether data is expected to arrive later than other data and thus would change previously evaluated results.

--- a/observe/data_source_dashboard.go
+++ b/observe/data_source_dashboard.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	observe "github.com/observeinc/terraform-provider-observe/client"
+	"github.com/observeinc/terraform-provider-observe/client/binding"
 )
 
 func dataSourceDashboard() *schema.Resource {
@@ -75,12 +76,59 @@ func dataSourceDashboardRead(ctx context.Context, data *schema.ResourceData, met
 		id     = data.Get("id").(string)
 	)
 
-	ws, err := client.GetDashboard(ctx, id)
+	dashboard, err := client.GetDashboard(ctx, id)
 	if err != nil {
 		diags = diag.FromErr(err)
 		return
 	}
-	data.SetId(ws.Id)
+	data.SetId(dashboard.Id)
 
-	return dashboardToResourceData(ctx, ws, data, client, true)
+	diags = dashboardToResourceData(dashboard, data)
+	if diags.HasError() {
+		return diags
+	}
+
+	if client.ExportObjectBindings {
+		bindFor := binding.NewKindSet(binding.KindDataset, binding.KindWorkspace)
+		gen, err := binding.NewGenerator(ctx, binding.KindDashboard, dashboard.Name, client, bindFor)
+		if err != nil {
+			return diag.Errorf("Failed to initialize binding generator: %s", err.Error())
+		}
+
+		// generate binding for workspace
+		if err := data.Set("workspace", gen.TryBind(binding.KindWorkspace, dashboard.WorkspaceId)); err != nil {
+			return diag.FromErr(err)
+		}
+
+		// generate bindings for workspace, stages, parameters, parameter_values, and layout,
+		// replacing the original ids in the json data with local variable references
+		for _, field := range []string{"stages", "parameters", "parameter_values", "layout"} {
+			jsonWithRawIds := data.Get(field).(string)
+			if jsonWithRawIds == "" {
+				continue
+			}
+			jsonWithReferences, err := gen.GenerateJson([]byte(jsonWithRawIds))
+			if err != nil {
+				return diag.Errorf("failed to generate bindings for field '%s': %s", field, err.Error())
+			}
+			if err := data.Set(field, string(jsonWithReferences)); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		// insert the bindings into the layout field to be used to generate data sources
+		// and local variable definitions at a later point
+		layout := data.Get("layout").(string)
+		if layout == "" {
+			layout = "{}"
+		}
+		layoutWithBindings, err := gen.InsertBindingsObjectJson([]byte(layout))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := data.Set("layout", string(layoutWithBindings)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return nil
 }

--- a/observe/data_source_dashboard.go
+++ b/observe/data_source_dashboard.go
@@ -99,11 +99,12 @@ func dataSourceDashboardRead(ctx context.Context, data *schema.ResourceData, met
 	return nil
 }
 
+// Generates bindings for use in cross-tenant exports of dashboards. See binding.go for details.
 func generateDashboardBindings(ctx context.Context, dashboard *gql.Dashboard, data *schema.ResourceData, client *observe.Client) error {
 	bindFor := binding.NewKindSet(binding.KindDataset, binding.KindWorkspace)
 	gen, err := binding.NewGenerator(ctx, binding.KindDashboard, dashboard.Name, client, bindFor)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize binding generator: %w", err)
+		return fmt.Errorf("failed to initialize binding generator: %w", err)
 	}
 
 	// generate binding for workspace

--- a/observe/data_source_dashboard.go
+++ b/observe/data_source_dashboard.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	observe "github.com/observeinc/terraform-provider-observe/client"
 	"github.com/observeinc/terraform-provider-observe/client/binding"
+	"github.com/observeinc/terraform-provider-observe/client/oid"
 )
 
 func dataSourceDashboard() *schema.Resource {
@@ -96,11 +97,12 @@ func dataSourceDashboardRead(ctx context.Context, data *schema.ResourceData, met
 		}
 
 		// generate binding for workspace
-		if err := data.Set("workspace", gen.TryBind(binding.KindWorkspace, dashboard.WorkspaceId)); err != nil {
+		workspaceRef, _ := gen.TryBindOid(oid.WorkspaceOid(dashboard.WorkspaceId))
+		if err := data.Set("workspace", workspaceRef); err != nil {
 			return diag.FromErr(err)
 		}
 
-		// generate bindings for workspace, stages, parameters, parameter_values, and layout,
+		// generate bindings for stages, parameters, parameter_values, and layout,
 		// replacing the original ids in the json data with local variable references
 		for _, field := range []string{"stages", "parameters", "parameter_values", "layout"} {
 			jsonWithRawIds := data.Get(field).(string)

--- a/observe/data_source_monitor.go
+++ b/observe/data_source_monitor.go
@@ -365,6 +365,7 @@ func dataSourceMonitor() *schema.Resource {
 	}
 }
 
+// Generates bindings for use in cross-tenant exports of monitor. See binding.go for details.
 func dataSourceMonitorRead(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 	var (
 		client     = meta.(*observe.Client)

--- a/observe/data_source_monitor.go
+++ b/observe/data_source_monitor.go
@@ -2,7 +2,7 @@ package observe
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -397,36 +397,40 @@ func dataSourceMonitorRead(ctx context.Context, data *schema.ResourceData, meta 
 	}
 
 	if client.ExportObjectBindings {
-		bindFor := binding.NewKindSet(binding.KindWorkspace, binding.KindDataset)
-		gen, err := binding.NewGenerator(ctx, binding.KindMonitor, m.Name, client, bindFor)
-		if err != nil {
-			return diag.Errorf("Failed to initialize binding generator: %s", err.Error())
-		}
-
-		// generate bindings for the workspace and inputs, replacing the original ids with locals
-		workspaceRef, _ := gen.TryBindOid(oid.WorkspaceOid(m.WorkspaceId))
-		if err := data.Set("workspace", workspaceRef); err != nil {
-			return diag.FromErr(err)
-		}
-		inputs := data.Get("inputs").(map[string]interface{})
-		gen.Generate(inputs)
-		if err := data.Set("inputs", inputs); err != nil {
-			return diag.FromErr(err)
-		}
-
-		// save the bindings to the _bindings field for later use
-		bindings, err := gen.GetBindings()
+		err := generateMonitorBindings(ctx, m, data, client)
 		if err != nil {
 			return diag.FromErr(err)
-		}
-		bindingsJson, err := json.Marshal(bindings)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		if err := data.Set("_bindings", string(bindingsJson)); err != nil {
-			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
 
 	return
+}
+
+func generateMonitorBindings(ctx context.Context, monitor *gql.Monitor, data *schema.ResourceData, client *observe.Client) error {
+	bindFor := binding.NewKindSet(binding.KindWorkspace, binding.KindDataset)
+	gen, err := binding.NewGenerator(ctx, binding.KindMonitor, monitor.Name, client, bindFor)
+	if err != nil {
+		return fmt.Errorf("Failed to initialize binding generator: %w", err)
+	}
+
+	// generate bindings for the workspace and inputs, replacing the original ids with local references
+	workspaceRef, _ := gen.TryBindOid(oid.WorkspaceOid(monitor.WorkspaceId))
+	if err := data.Set("workspace", workspaceRef); err != nil {
+		return err
+	}
+	inputs := data.Get("inputs").(map[string]interface{})
+	gen.Generate(inputs)
+	if err := data.Set("inputs", inputs); err != nil {
+		return err
+	}
+
+	// save the bindings to the _bindings field for later use in generating data sources + locals
+	bindingsJson, err := gen.GetBindingsJson()
+	if err != nil {
+		return err
+	}
+	if err := data.Set("_bindings", string(bindingsJson)); err != nil {
+		return err
+	}
+	return nil
 }

--- a/observe/data_source_monitor.go
+++ b/observe/data_source_monitor.go
@@ -404,7 +404,8 @@ func dataSourceMonitorRead(ctx context.Context, data *schema.ResourceData, meta 
 		}
 
 		// generate bindings for the workspace and inputs, replacing the original ids with locals
-		if err := data.Set("workspace", gen.TryBind(binding.KindWorkspace, m.WorkspaceId)); err != nil {
+		workspaceRef, _ := gen.TryBindOid(oid.WorkspaceOid(m.WorkspaceId))
+		if err := data.Set("workspace", workspaceRef); err != nil {
 			return diag.FromErr(err)
 		}
 		inputs := data.Get("inputs").(map[string]interface{})

--- a/observe/data_source_monitor_test.go
+++ b/observe/data_source_monitor_test.go
@@ -321,11 +321,11 @@ func TestAccObserveMonitorExportWithBindings(t *testing.T) {
 						if !reflect.DeepEqual(bindings.Kinds, expectedKinds) {
 							return fmt.Errorf("bindings.Kind does not match: Expected %#v, got %#v", expectedKinds, bindings.Kinds)
 						}
-						expectedWorkspaceBinding := binding.Target{TfLocalBindingVar: workspaceTfLocalBindingVar, TfName: workspaceTfName}
+						expectedWorkspaceBinding := binding.Target{TfLocalBindingVar: workspaceTfLocalBindingVar, TfName: workspaceTfName, IsOid: true}
 						if bindings.Workspace != expectedWorkspaceBinding {
 							return fmt.Errorf("bindings.Workspace does not match: Expected %#v, got %#v", expectedWorkspaceBinding, bindings.Workspace)
 						}
-						expectedDatasetBinding := binding.Target{TfLocalBindingVar: datasetTfLocalBindingVar, TfName: datasetTfName}
+						expectedDatasetBinding := binding.Target{TfLocalBindingVar: datasetTfLocalBindingVar, TfName: datasetTfName, IsOid: true}
 						if binding, ok := bindings.Mappings[binding.Ref{Kind: binding.KindDataset, Key: randomPrefixDataset}]; !ok || binding != expectedDatasetBinding {
 							return fmt.Errorf("bindings.Mappings does contain expected binding %#v for dataset %s, found bindings: %#v", expectedDatasetBinding, randomPrefixDataset, bindings.Mappings)
 						}

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -564,11 +564,12 @@ func dataSourceMonitorV2Read(ctx context.Context, data *schema.ResourceData, met
 	return
 }
 
+// Generates bindings for use in cross-tenant exports of monitor v2. See binding.go for details.
 func generateMonitorV2Bindings(ctx context.Context, monitor *gql.MonitorV2, data *schema.ResourceData, client *observe.Client) error {
 	bindFor := binding.NewKindSet(binding.KindDataset, binding.KindWorkspace, binding.KindMonitorV2Action)
 	gen, err := binding.NewGenerator(ctx, binding.KindMonitorV2, monitor.Name, client, bindFor)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize binding generator: %w", err)
+		return fmt.Errorf("failed to initialize binding generator: %w", err)
 	}
 
 	// generate bindings for the workspace, inputs, and actions, replacing the original ids

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -563,7 +563,8 @@ func dataSourceMonitorV2Read(ctx context.Context, data *schema.ResourceData, met
 
 		// generate bindings for the workspace, inputs, and actions, replacing the original ids
 		// with local variable references
-		if err := data.Set("workspace", gen.TryBind(binding.KindWorkspace, m.WorkspaceId)); err != nil {
+		workspaceRef, _ := gen.TryBindOid(oid.WorkspaceOid(m.WorkspaceId))
+		if err := data.Set("workspace", workspaceRef); err != nil {
 			return diag.FromErr(err)
 		}
 		for _, field := range []string{"inputs", "actions"} {

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -2,10 +2,12 @@ package observe
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	observe "github.com/observeinc/terraform-provider-observe/client"
+	"github.com/observeinc/terraform-provider-observe/client/binding"
 	gql "github.com/observeinc/terraform-provider-observe/client/meta"
 	"github.com/observeinc/terraform-provider-observe/client/oid"
 	"github.com/observeinc/terraform-provider-observe/observe/descriptions"
@@ -388,6 +390,11 @@ func dataSourceMonitorV2() *schema.Resource {
 				},
 				Description: descriptions.Get("monitorv2", "schema", "actions", "description"),
 			},
+			"_bindings": { // internal, used for generating bindings for cross-tenant export
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("monitorv2", "schema", "_bindings"),
+			},
 		},
 	}
 }
@@ -542,5 +549,44 @@ func dataSourceMonitorV2Read(ctx context.Context, data *schema.ResourceData, met
 	}
 
 	data.SetId(m.Id)
-	return resourceMonitorV2Read(ctx, data, meta)
+	diags = monitorV2ToResourceData(ctx, m, data, client)
+	if diags.HasError() {
+		return diags
+	}
+
+	if client.ExportObjectBindings {
+		bindFor := binding.NewKindSet(binding.KindDataset, binding.KindWorkspace, binding.KindMonitorV2Action)
+		gen, err := binding.NewGenerator(ctx, binding.KindMonitorV2, m.Name, client, bindFor)
+		if err != nil {
+			return diag.Errorf("Failed to initialize binding generator: %s", err.Error())
+		}
+
+		// generate bindings for the workspace, inputs, and actions, replacing the original ids
+		// with local variable references
+		if err := data.Set("workspace", gen.TryBind(binding.KindWorkspace, m.WorkspaceId)); err != nil {
+			return diag.FromErr(err)
+		}
+		for _, field := range []string{"inputs", "actions"} {
+			value := data.Get(field)
+			gen.Generate(value)
+			if err := data.Set(field, value); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		// save the bindings to the _bindings field
+		bindings, err := gen.GetBindings()
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		bindingsJson, err := json.Marshal(bindings)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := data.Set("_bindings", string(bindingsJson)); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	}
+
+	return
 }

--- a/observe/data_source_monitor_v2_action.go
+++ b/observe/data_source_monitor_v2_action.go
@@ -160,17 +160,23 @@ func dataSourceMonitorV2ActionRead(ctx context.Context, data *schema.ResourceDat
 
 	if getID != "" {
 		act, err = client.GetMonitorV2Action(ctx, getID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	} else if name != "" {
 		workspaceID, _ := data.Get("workspace").(string)
 		if workspaceID != "" {
-			act, err = client.SearchMonitorV2Action(ctx, &workspaceID, &name)
+			actions, err := client.SearchMonitorV2Action(ctx, &workspaceID, &name)
+			if err != nil {
+				return diag.FromErr(err)
+			} else if len(actions) != 1 {
+				return diag.Errorf("found %d monitor actions with name %q", len(actions), name)
+			}
+			act = &actions[0]
 		}
 	}
 
-	if err != nil {
-		diags = diag.FromErr(err)
-		return
-	} else if act == nil {
+	if act == nil {
 		return diag.Errorf("failed to lookup monitor action from provided get/search parameters")
 	}
 

--- a/observe/data_source_monitor_v2_test.go
+++ b/observe/data_source_monitor_v2_test.go
@@ -294,15 +294,15 @@ func TestAccObserveMonitorV2ExportWithBindings(t *testing.T) {
 						if !reflect.DeepEqual(bindings.Kinds, expectedKinds) {
 							return fmt.Errorf("bindings.Kind does not match: Expected %#v, got %#v", expectedKinds, bindings.Kinds)
 						}
-						expectedWorkspaceBinding := binding.Target{TfLocalBindingVar: workspaceTfLocalBindingVar, TfName: workspaceTfName}
+						expectedWorkspaceBinding := binding.Target{TfLocalBindingVar: workspaceTfLocalBindingVar, TfName: workspaceTfName, IsOid: true}
 						if bindings.Workspace != expectedWorkspaceBinding {
 							return fmt.Errorf("bindings.Workspace does not match: Expected %#v, got %#v", expectedWorkspaceBinding, bindings.Workspace)
 						}
-						expectedDatasetBinding := binding.Target{TfLocalBindingVar: datasetTfLocalBindingVar, TfName: datasetTfName}
+						expectedDatasetBinding := binding.Target{TfLocalBindingVar: datasetTfLocalBindingVar, TfName: datasetTfName, IsOid: true}
 						if binding, ok := bindings.Mappings[binding.Ref{Kind: binding.KindDataset, Key: randomPrefixDataset}]; !ok || binding != expectedDatasetBinding {
 							return fmt.Errorf("bindings.Mappings does contain expected binding %#v for dataset %s, found bindings: %#v", expectedDatasetBinding, randomPrefixDataset, bindings.Mappings)
 						}
-						expectedActionBinding := binding.Target{TfLocalBindingVar: actionTfLocalBindingVar, TfName: actionTfName}
+						expectedActionBinding := binding.Target{TfLocalBindingVar: actionTfLocalBindingVar, TfName: actionTfName, IsOid: true}
 						if binding, ok := bindings.Mappings[binding.Ref{Kind: binding.KindMonitorV2Action, Key: randomPrefixMonitorAction}]; !ok || binding != expectedActionBinding {
 							return fmt.Errorf("bindings.Mappings does contain expected binding %#v for action %s, found bindings: %#v", expectedActionBinding, randomPrefixMonitorAction, bindings.Mappings)
 						}

--- a/observe/descriptions/monitor.yaml
+++ b/observe/descriptions/monitor.yaml
@@ -73,3 +73,5 @@ schema:
         An id of the stage that is used to generate logs for preview. This is usually a stage before aggregation.
       source_log_dataset: |
         ID of the dataset that contains logs for preview.
+  _bindings: |
+    Internal field. Do not use.

--- a/observe/descriptions/monitorv2.yaml
+++ b/observe/descriptions/monitorv2.yaml
@@ -131,3 +131,5 @@ schema:
       If true, notifications will be sent if the monitor stops triggering.
     send_reminders_interval: |
       Determines how frequently you will be reminded of an ongoing alert.
+  _bindings: |
+    Internal field. Do not use.

--- a/observe/resource_dashboard.go
+++ b/observe/resource_dashboard.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	observe "github.com/observeinc/terraform-provider-observe/client"
-	"github.com/observeinc/terraform-provider-observe/client/binding"
 	gql "github.com/observeinc/terraform-provider-observe/client/meta"
 	"github.com/observeinc/terraform-provider-observe/client/meta/types"
 	"github.com/observeinc/terraform-provider-observe/client/oid"
@@ -142,15 +141,8 @@ func newDashboardConfig(data *schema.ResourceData) (input *gql.DashboardInput, d
 	return input, diags
 }
 
-func dashboardToResourceData(ctx context.Context, d *gql.Dashboard, data *schema.ResourceData,
-	client *observe.Client, genBindings bool) (diags diag.Diagnostics) {
-	bindFor := binding.NewKindSet(binding.KindDataset, binding.KindWorkspace)
-	gen, err := binding.NewGenerator(ctx, genBindings, "dashboard", d.Name, client, bindFor)
-	if err != nil {
-		return diag.Errorf("Failed to initialize binding generator: %s", err.Error())
-	}
-
-	if err := data.Set("workspace", gen.TryBind(binding.KindWorkspace, d.WorkspaceId)); err != nil {
+func dashboardToResourceData(d *gql.Dashboard, data *schema.ResourceData) (diags diag.Diagnostics) {
+	if err := data.Set("workspace", oid.WorkspaceOid(d.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
@@ -184,9 +176,6 @@ func dashboardToResourceData(ctx context.Context, d *gql.Dashboard, data *schema
 		if stagesRaw, err := json.Marshal(d.Stages); err != nil {
 			diagErr := fmt.Errorf("failed to parse 'stages' response field: %w", err)
 			diags = append(diags, diag.FromErr(diagErr)...)
-		} else if stagesRaw, err := gen.GenerateJson(stagesRaw); err != nil {
-			diagErr := fmt.Errorf("failed to generate bindings for 'stages' response field: %w", err)
-			diags = append(diags, diag.FromErr(diagErr)...)
 		} else if err := data.Set("stages", string(stagesRaw)); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		}
@@ -195,9 +184,6 @@ func dashboardToResourceData(ctx context.Context, d *gql.Dashboard, data *schema
 	if d.Parameters != nil {
 		if parametersRaw, err := json.Marshal(d.Parameters); err != nil {
 			diagErr := fmt.Errorf("failed to parse 'parameters' response field: %w", err)
-			diags = append(diags, diag.FromErr(diagErr)...)
-		} else if parametersRaw, err := gen.GenerateJson(parametersRaw); err != nil {
-			diagErr := fmt.Errorf("failed to generate bindings for 'parameters' response field: %w", err)
 			diags = append(diags, diag.FromErr(diagErr)...)
 		} else if err := data.Set("parameters", string(parametersRaw)); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
@@ -208,34 +194,15 @@ func dashboardToResourceData(ctx context.Context, d *gql.Dashboard, data *schema
 		if parameterValuesRaw, err := json.Marshal(d.ParameterValues); err != nil {
 			diagErr := fmt.Errorf("failed to parse 'parameter_values' response field: %w", err)
 			diags = append(diags, diag.FromErr(diagErr)...)
-		} else if parameterValuesRaw, err := gen.GenerateJson(parameterValuesRaw); err != nil {
-			diagErr := fmt.Errorf("failed to generate bindings for 'parameterValuesRaw' response field: %w", err)
-			diags = append(diags, diag.FromErr(diagErr)...)
 		} else if err := data.Set("parameter_values", string(parameterValuesRaw)); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
 
-	if d.Layout != nil || gen.Enabled {
-		if d.Layout == nil {
-			empty := types.JsonObject("{}")
-			d.Layout = &empty
+	if d.Layout != nil {
+		if err := data.Set("layout", d.Layout); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
 		}
-		if layout, err := d.Layout.MarshalJSON(); err != nil {
-			diagErr := fmt.Errorf("failed to parse 'layout' response field: %w", err)
-			diags = append(diags, diag.FromErr(diagErr)...)
-		} else if layout, err := gen.GenerateJson(layout); err != nil {
-			diagErr := fmt.Errorf("failed to generate bindings for 'layout' response field: %w", err)
-			diags = append(diags, diag.FromErr(diagErr)...)
-		} else {
-			layoutJson := types.JsonObject(string(layout))
-			if layout, err := gen.InsertBindingsObjectJson(&layoutJson); err != nil {
-				diags = append(diags, diag.FromErr(err)...)
-			} else if err := data.Set("layout", layout); err != nil {
-				diags = append(diags, diag.FromErr(err)...)
-			}
-		}
-
 	}
 
 	if err := data.Set("oid", d.Oid().String()); err != nil {
@@ -282,7 +249,7 @@ func resourceDashboardRead(ctx context.Context, data *schema.ResourceData, meta 
 		})
 	}
 
-	return dashboardToResourceData(ctx, result, data, client, false)
+	return dashboardToResourceData(result, data)
 }
 
 func resourceDashboardUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -303,7 +270,7 @@ func resourceDashboardUpdate(ctx context.Context, data *schema.ResourceData, met
 		return diags
 	}
 
-	return dashboardToResourceData(ctx, result, data, client, false)
+	return dashboardToResourceData(result, data)
 }
 
 func resourceDashboardDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_dashboard.go
+++ b/observe/resource_dashboard.go
@@ -150,7 +150,7 @@ func dashboardToResourceData(ctx context.Context, d *gql.Dashboard, data *schema
 		return diag.Errorf("Failed to initialize binding generator: %s", err.Error())
 	}
 
-	if err := data.Set("workspace", gen.TryBind(binding.KindWorkspace, oid.WorkspaceOid(d.WorkspaceId).String())); err != nil {
+	if err := data.Set("workspace", gen.TryBind(binding.KindWorkspace, d.WorkspaceId)); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 

--- a/observe/resource_monitor.go
+++ b/observe/resource_monitor.go
@@ -800,6 +800,10 @@ func resourceMonitorRead(ctx context.Context, data *schema.ResourceData, meta in
 		return diag.Errorf("failed to read monitor: %s", err.Error())
 	}
 
+	return monitorToResourceData(data, monitor)
+}
+
+func monitorToResourceData(data *schema.ResourceData, monitor *gql.Monitor) (diags diag.Diagnostics) {
 	if err := data.Set("workspace", oid.WorkspaceOid(monitor.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -623,7 +623,18 @@ func resourceMonitorV2Read(ctx context.Context, data *schema.ResourceData, meta 
 		return diag.Errorf("failed to read monitorv2: %s", err.Error())
 	}
 
-	// perform data.set on all the fields from this monitor
+	return monitorV2ToResourceData(ctx, monitor, data, client)
+}
+
+func resourceMonitorV2Delete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
+	client := meta.(*observe.Client)
+	if err := client.DeleteMonitorV2(ctx, data.Id()); err != nil {
+		return diag.Errorf("failed to delete monitor: %s", err.Error())
+	}
+	return diags
+}
+
+func monitorV2ToResourceData(ctx context.Context, monitor *gql.MonitorV2, data *schema.ResourceData, client *observe.Client) (diags diag.Diagnostics) {
 	if err := data.Set("workspace", oid.WorkspaceOid(monitor.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -652,7 +663,7 @@ func resourceMonitorV2Read(ctx context.Context, data *schema.ResourceData, meta 
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	_, err = flattenAndSetQuery(data, monitor.Definition.InputQuery.Stages, monitor.Definition.InputQuery.OutputStage)
+	_, err := flattenAndSetQuery(data, monitor.Definition.InputQuery.Stages, monitor.Definition.InputQuery.OutputStage)
 	if err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -705,14 +716,6 @@ func resourceMonitorV2Read(ctx context.Context, data *schema.ResourceData, meta 
 		}
 	}
 
-	return diags
-}
-
-func resourceMonitorV2Delete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
-	client := meta.(*observe.Client)
-	if err := client.DeleteMonitorV2(ctx, data.Id()); err != nil {
-		return diag.Errorf("failed to delete monitor: %s", err.Error())
-	}
 	return diags
 }
 


### PR DESCRIPTION
Similar to the existing approach for dashboards, generates "bindings" to a terraform local variable for each id found in the monitor definition to support cross-tenant exports. Unlike with dashboards, monitors don't have a `layout` field to insert these bindings into for later consumption, so instead added a new `_bindings` field to the data source to hold this information.

Broken into separate commits for ease of reviewing.