### PR TITLE
fix: ingest-filter enabled field not accounted for

### DIFF
--- a/observe/resource_drop_filter.go
+++ b/observe/resource_drop_filter.go
@@ -110,6 +110,10 @@ func ingestFilterToResourceData(filter *gql.IngestFilter, data *schema.ResourceD
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
+	if err := data.Set("enabled", filter.Enabled); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+
 	return diags
 }
 


### PR DESCRIPTION
I noticed that if I disabled the filter from ui, tf wouldn't see the difference. This should fix the issue.