### PR TITLE
test: increase timeout

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -98,7 +98,7 @@ testacc:
 		--rerun-fails=3 \
 		-- \
 		-parallel=5 \
-		-timeout 30m \
+		-timeout 45m \
 		$(TESTARGS)
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
From what I can tell, we have tests failing somewhat often just due to some tests taking a long time even when there isn't a server restart (the prior theory for the sporadic failures). Need to reduce the time tests are taking somehow, but increasing the timeout for now.