### PR TITLE
feat(monitor_v2): support providing operator for action conditions

### DIFF
--- a/client/internal/meta/operation/monitorv2.graphql
+++ b/client/internal/meta/operation/monitorv2.graphql
@@ -206,7 +206,8 @@ fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
     compareTerms {
         ...MonitorV2ComparisonTerm
     }
-    # subExpressions/operator are not used by the UI so we won't support them here yet either
+    operator
+    # subExpressions are not used by the UI so we won't support them here yet either
 }
 
 fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -6582,12 +6582,16 @@ func (v *MonitorV2Comparison) GetCompareValue() PrimitiveValue { return v.Compar
 // MonitorV2ComparisonExpression includes the GraphQL fields of MonitorV2ComparisonExpression requested by the fragment MonitorV2ComparisonExpression.
 type MonitorV2ComparisonExpression struct {
 	CompareTerms []MonitorV2ComparisonTerm `json:"compareTerms"`
+	Operator     MonitorV2BooleanOperator  `json:"operator"`
 }
 
 // GetCompareTerms returns MonitorV2ComparisonExpression.CompareTerms, and is useful for accessing the field via an interface.
 func (v *MonitorV2ComparisonExpression) GetCompareTerms() []MonitorV2ComparisonTerm {
 	return v.CompareTerms
 }
+
+// GetOperator returns MonitorV2ComparisonExpression.Operator, and is useful for accessing the field via an interface.
+func (v *MonitorV2ComparisonExpression) GetOperator() MonitorV2BooleanOperator { return v.Operator }
 
 type MonitorV2ComparisonExpressionInput struct {
 	CompareTerms   []MonitorV2ComparisonTermInput       `json:"compareTerms"`
@@ -16165,6 +16169,7 @@ fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
 	compareTerms {
 		... MonitorV2ComparisonTerm
 	}
+	operator
 }
 fragment MonitorV2ActionDefinition on MonitorV2ActionDefinition {
 	inline
@@ -19983,6 +19988,7 @@ fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
 	compareTerms {
 		... MonitorV2ComparisonTerm
 	}
+	operator
 }
 fragment MonitorV2ActionDefinition on MonitorV2ActionDefinition {
 	inline
@@ -21752,6 +21758,7 @@ fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
 	compareTerms {
 		... MonitorV2ComparisonTerm
 	}
+	operator
 }
 fragment MonitorV2ActionDefinition on MonitorV2ActionDefinition {
 	inline
@@ -22467,6 +22474,7 @@ fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
 	compareTerms {
 		... MonitorV2ComparisonTerm
 	}
+	operator
 }
 fragment MonitorV2ActionDefinition on MonitorV2ActionDefinition {
 	inline
@@ -22725,6 +22733,7 @@ fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
 	compareTerms {
 		... MonitorV2ComparisonTerm
 	}
+	operator
 }
 fragment MonitorV2ActionDefinition on MonitorV2ActionDefinition {
 	inline
@@ -24691,6 +24700,7 @@ fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
 	compareTerms {
 		... MonitorV2ComparisonTerm
 	}
+	operator
 }
 fragment MonitorV2ActionDefinition on MonitorV2ActionDefinition {
 	inline

--- a/client/meta/helpers.go
+++ b/client/meta/helpers.go
@@ -166,6 +166,11 @@ var AllMonitorV2HttpTypes = []MonitorV2HttpType{
 	MonitorV2HttpTypePut,
 }
 
+var AllMonitorV2BooleanOperators = []MonitorV2BooleanOperator{
+	MonitorV2BooleanOperatorAnd,
+	MonitorV2BooleanOperatorOr,
+}
+
 var AllAccelerationDisabledSource = []AccelerationDisabledSource{
 	AccelerationDisabledSourceEmpty,
 	AccelerationDisabledSourceMonitor,

--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -174,6 +174,7 @@ Read-Only:
 Read-Only:
 
 - `compare_terms` (Block List) (see [below for nested schema](#nestedblock--actions--conditions--compare_terms))
+- `operator` (String) Boolean operator to combine the list of compare terms. Can be "and" (default) or "or".
 
 <a id="nestedblock--actions--conditions--compare_terms"></a>
 ### Nested Schema for `actions.conditions.compare_terms`

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -434,6 +434,10 @@ Required:
 
 - `compare_terms` (Block List, Min: 1) (see [below for nested schema](#nestedblock--actions--conditions--compare_terms))
 
+Optional:
+
+- `operator` (String) Boolean operator to combine the list of compare terms. Can be "and" (default) or "or".
+
 <a id="nestedblock--actions--conditions--compare_terms"></a>
 ### Nested Schema for `actions.conditions.compare_terms`
 

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -414,7 +414,11 @@ func dataSourceMonitorV2() *schema.Resource {
 											},
 										},
 									},
-									// note: operator is an implied AND for now until the UI supports OR
+									"operator": { // MonitorV2BooleanOperator!
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: descriptions.Get("monitorv2", "schema", "actions", "conditions", "operator"),
+									},
 								},
 							},
 						},

--- a/observe/descriptions/monitorv2.yaml
+++ b/observe/descriptions/monitorv2.yaml
@@ -130,11 +130,13 @@ schema:
         Optional conditions that can be AND'd with levels to match the action.
       compare_terms:
         description: |
-          The column and value expression to consider (implied AND)
+          The column and value expression to consider
         comparison:
           The comparison operation and right-side value to evaluate
         column:
           The column (left-side) value to evaluate
+      operator: |
+        Boolean operator to combine the list of compare terms. Can be "and" (default) or "or".
     send_end_notifications: |
       If true, notifications will be sent if the monitor stops triggering.
     send_reminders_interval: |

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -387,6 +387,17 @@ func TestAccObserveMonitorV2MultipleActionsViaOneShot(t *testing.T) {
 										}
 									}
 								}
+								compare_terms {
+									comparison {
+										compare_fn = "equal"
+										value_string = ["test"]
+									}
+									column {
+										column_path  {
+											name = "kind"
+										}
+									}
+								}
 							}
 							send_end_notifications = false
 							send_reminders_interval = "20m"
@@ -422,9 +433,13 @@ func TestAccObserveMonitorV2MultipleActionsViaOneShot(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.action.0.type", "email"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.action.0.description", "an interesting description 2"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.send_reminders_interval", "20m0s"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.conditions.0.operator", "and"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.conditions.0.compare_terms.0.comparison.0.compare_fn", "equal"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.conditions.0.compare_terms.0.comparison.0.value_string.0", "test"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.conditions.0.compare_terms.0.column.0.column_path.0.name", "description"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.conditions.0.compare_terms.1.comparison.0.compare_fn", "equal"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.conditions.0.compare_terms.1.comparison.0.value_string.0", "test"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.conditions.0.compare_terms.1.column.0.column_path.0.name", "kind"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.action.0.type", "webhook"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.action.0.description", "an interesting description 3"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.action.0.webhook.0.url", "https://example.com"),
@@ -522,14 +537,26 @@ func TestAccObserveMonitorV2MultipleActionsViaOneShot(t *testing.T) {
 							}
 							levels = ["informational"]
 							conditions {
+								operator = "or"
 								compare_terms {
 									comparison {
 										compare_fn = "equal"
-										value_string = ["test"] 
+										value_string = ["test"]
 									}
 									column {
 										column_path  {
 											name = "description"
+										}
+									}
+								}
+								compare_terms {
+									comparison {
+										compare_fn = "equal"
+										value_string = ["test"]
+									}
+									column {
+										column_path  {
+											name = "kind"
 										}
 									}
 								}
@@ -554,6 +581,11 @@ func TestAccObserveMonitorV2MultipleActionsViaOneShot(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.action.0.type", "email"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.action.0.description", "an interesting description 2"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.send_reminders_interval", "22m0s"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.conditions.0.operator", "or"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.conditions.0.compare_terms.0.comparison.0.compare_fn", "equal"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.conditions.0.compare_terms.0.column.0.column_path.0.name", "description"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.conditions.0.compare_terms.1.comparison.0.compare_fn", "equal"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.2.conditions.0.compare_terms.1.column.0.column_path.0.name", "kind"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "custom_variables", `{"fizz":"buzz"}`),
 				),
 			},


### PR DESCRIPTION
Was previously left out since the UI didn't support it yet. We now have UI support, so adding `operator` is necessary for accurate exports. Tested the export flow as well.