### PR TITLE
fix: replacing monitor v2 inline action with shared action

### DIFF
--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -41,6 +41,14 @@ resource "observe_monitor_v2" "example" {
       name = "Dashboard"
     }
   }
+
+  no_data_rules {
+    threshold {
+      value_column_name = "A_credits_adhoc_query_sum"
+      aggregation       = "all_of"
+    }
+  }
+
   rules {
     level = "error"
     threshold {
@@ -55,6 +63,7 @@ resource "observe_monitor_v2" "example" {
       }
     }
   }
+
   stage {
     output_stage = false
     pipeline     = <<-EOT

--- a/examples/resources/observe_monitor_v2/resource.tf
+++ b/examples/resources/observe_monitor_v2/resource.tf
@@ -23,6 +23,14 @@ resource "observe_monitor_v2" "example" {
       name = "Dashboard"
     }
   }
+
+  no_data_rules {
+    threshold {
+      value_column_name = "A_credits_adhoc_query_sum"
+      aggregation       = "all_of"
+    }
+  }
+
   rules {
     level = "error"
     threshold {
@@ -37,6 +45,7 @@ resource "observe_monitor_v2" "example" {
       }
     }
   }
+
   stage {
     output_stage = false
     pipeline     = <<-EOT


### PR DESCRIPTION
- works around Terraform SDK limitation preventing replacing an inline action with a shared action from working, see comments for more details
- also add example for no_data_rules