### PR TITLE
fix: support NoData monitor v2 alarm level for actions

### DIFF
--- a/client/meta/helpers.go
+++ b/client/meta/helpers.go
@@ -137,6 +137,7 @@ var AllMonitorV2AlarmLevels = []MonitorV2AlarmLevel{
 	MonitorV2AlarmLevelInformational,
 	MonitorV2AlarmLevelNone,
 	MonitorV2AlarmLevelWarning,
+	MonitorV2AlarmLevelNodata,
 }
 
 var AllMonitorV2ValueAggregations = []MonitorV2ValueAggregation{

--- a/observe/helpers.go
+++ b/observe/helpers.go
@@ -538,3 +538,14 @@ func sliceContains[T comparable](slice []T, val T) bool {
 	}
 	return false
 }
+
+// sliceExclude returns a new slice with the specified elements filtered out
+func sliceExclude[T comparable](slice []T, exclude ...T) []T {
+	result := make([]T, 0, len(slice))
+	for _, v := range slice {
+		if !sliceContains(exclude, v) {
+			result = append(result, v)
+		}
+	}
+	return result
+}

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -163,9 +163,10 @@ func resourceMonitorV2() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"level": { // MonitorV2AlarmLevel!
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: validateEnums(gql.AllMonitorV2AlarmLevels),
+							Type:     schema.TypeString,
+							Required: true,
+							// To create a NoData rule, must use no_data_rules block instead
+							ValidateDiagFunc: validateEnums(sliceExclude(gql.AllMonitorV2AlarmLevels, gql.MonitorV2AlarmLevelNodata)),
 							Description:      descriptions.Get("monitorv2", "schema", "rules", "level"),
 						},
 						"count": { // MonitorV2CountRuleInput

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -503,7 +503,7 @@ func TestAccObserveMonitorV2MultipleActionsViaOneShot(t *testing.T) {
 								}
 								description = "an interesting description 1"
 							}
-							levels = ["informational"]
+							levels = ["no_data"]
 							send_end_notifications = true
 							send_reminders_interval = "11m"
 						}
@@ -575,6 +575,7 @@ func TestAccObserveMonitorV2MultipleActionsViaOneShot(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.0.action.0.type", "email"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.0.action.0.description", "an interesting description 1"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.0.send_reminders_interval", "11m0s"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.0.levels.0", "no_data"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.action.0.type", "webhook"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.action.0.description", "an interesting description 3 - reordered"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "actions.1.send_reminders_interval", "33m0s"),


### PR DESCRIPTION
While specifying `NoData` is invalid as the level for a rule (should use the separate `no_data_rules` block instead), it is valid as a level for an action. Added it to the list of alarm levels but excluded it from the validation for `rules`