### PR TITLE
fix: deprecate freshness for source datasets

### DIFF
--- a/docs/resources/source_dataset.md
+++ b/docs/resources/source_dataset.md
@@ -26,7 +26,7 @@ description: |-
 
 - `batch_seq_field` (String)
 - `description` (String)
-- `freshness` (String)
+- `freshness` (String, Deprecated)
 - `icon_url` (String)
 - `is_insert_only` (Boolean)
 

--- a/observe/resource_source_dataset.go
+++ b/observe/resource_source_dataset.go
@@ -126,6 +126,7 @@ func resourceSourceDataset() *schema.Resource {
 				Computed: true,
 			},
 			"freshness": {
+				Deprecated:       "Freshness is not meaningful for source datasets.",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: validateTimeDuration,

--- a/observe/resource_source_dataset_test.go
+++ b/observe/resource_source_dataset_test.go
@@ -99,7 +99,6 @@ func TestAccObserveSourceDatasetResource(t *testing.T) {
 				resource "observe_source_dataset" "first" {
 					workspace = data.observe_workspace.default.oid
 					name 	  = "%s"
-					freshness = "1m"
 
 					schema = "EXTERNAL2"
 					table_name = "%s_TABLE_NAME2"
@@ -139,7 +138,6 @@ func TestAccObserveSourceDatasetResource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("observe_source_dataset.first", "workspace"),
 					resource.TestCheckResourceAttr("observe_source_dataset.first", "name", randomPrefix+"-rename"),
-					resource.TestCheckResourceAttr("observe_source_dataset.first", "freshness", "1m0s"),
 					resource.TestCheckResourceAttr("observe_source_dataset.first", "schema", "EXTERNAL2"),
 					resource.TestCheckResourceAttr("observe_source_dataset.first", "table_name", randomTablePrefix+"_TABLE_NAME2"),
 					resource.TestCheckResourceAttr("observe_source_dataset.first", "source_update_table_name", randomTablePrefix+"_SOURCE_UPDATE_TABLE_NAME2"),


### PR DESCRIPTION
freshness goals are meaningless for source datasets since there is no transform