### PR TITLE
fix[drop filter]: diff suppress oid version

### DIFF
--- a/observe/resource_drop_filter.go
+++ b/observe/resource_drop_filter.go
@@ -62,6 +62,7 @@ func resourceDropFilter() *schema.Resource {
 				Required:         true,
 				Description:      descriptions.Get("drop_filter", "schema", "source_dataset"),
 				ValidateDiagFunc: validateOID(oid.TypeDataset),
+				DiffSuppressFunc: diffSuppressOIDVersion,
 			},
 		},
 	}


### PR DESCRIPTION
Currently causing a perpetual diff when an observe_dataset.oid is used (which includes the version) instead of using observe_datastream.dataset