### PR TITLE
tests: Fix dataset edit-forward tests

### DIFF
--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -612,7 +612,7 @@ func TestAccObserveDatasetEditForwardDryRun(t *testing.T) {
 
 					stage {
 						pipeline = <<-EOF
-							make_col x: 1
+							make_resource primary_key(OBSERVATION_KIND)
 						EOF
 					}
 				}`, randomPrefix),
@@ -640,7 +640,7 @@ func TestAccObserveDatasetEditForwardDryRun(t *testing.T) {
 					rematerialization_mode = "must_skip_rematerialization"
 					stage {
 							pipeline = <<-EOF
-							make_col x: 1, y: 2
+							make_resource primary_key(OBSERVATION_KIND, BUNDLE_ID)
 						EOF
 					}
 				}`, randomPrefix),
@@ -670,7 +670,7 @@ func TestAccObserveDatasetEditForwardNoDryRun(t *testing.T) {
 
 					stage {
 						pipeline = <<-EOF
-							make_col x: 1
+							make_resource primary_key(OBSERVATION_KIND)
 						EOF
 					}
 				}`, randomPrefix),
@@ -698,7 +698,7 @@ func TestAccObserveDatasetEditForwardNoDryRun(t *testing.T) {
 					rematerialization_mode = "skip_rematerialization"
 					stage {
 							pipeline = <<-EOF
-							make_col x: 1, y: 2
+							make_resource primary_key(OBSERVATION_KIND, BUNDLE_ID)
 						EOF
 					}
 				}`, randomPrefix),


### PR DESCRIPTION
Since dataset schemas can be changed now, change the edit-forward test to use make_resource instead - changing the primary key set should always trigger rematerialization.