### PR TITLE
feature: Allow setting default rematerialization option

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -55,6 +55,9 @@ type Config struct {
 
 	// enable extra queries needed to export bindings
 	ExportObjectBindings bool `json:"export_object_bindings"`
+
+	// Allow setting default materialization mode for dataset resources
+	DefaultRematerializationMode *string `json:"default_rematerialization_mode"`
 }
 
 func (c *Config) Hash() uint64 {

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,7 @@ terraform plan
 ### Optional
 
 - `api_token` (String, Sensitive) An Observe API Token. Used for authenticating requests to API in the absence of `user_email` and `user_password`.
+- `default_rematerialization_mode` (String) Default rematerialization mode for datasets (internal use).
 - `domain` (String) Observe API domain. Defaults to `observeinc.com`.
 - `export_object_bindings` (Boolean) Enable generating object ID-name bindings for cross-tenant export/import (internal use).
 - `flags` (String) Toggle experimental features.

--- a/observe/provider.go
+++ b/observe/provider.go
@@ -121,6 +121,13 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: "Enable generating object ID-name bindings for cross-tenant export/import (internal use).",
 			},
+			"default_rematerialization_mode": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateEnums(AllRematerializationModes),
+				Description:      "Default rematerialization mode for datasets (internal use).",
+				DefaultFunc:      schema.EnvDefaultFunc("OBSERVE_DEFAULT_REMATERIALIZATION_MODE", nil),
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -282,6 +289,11 @@ func getConfigureContextFunc(userAgent func() string) schema.ConfigureContextFun
 		// refer https://www.w3.org/TR/trace-context/#traceparent-header
 		if traceparent := os.Getenv("TRACEPARENT"); traceparent != "" {
 			config.TraceParent = &traceparent
+		}
+
+		if v, ok := data.GetOk("default_rematerialization_mode"); ok {
+			s := v.(string)
+			config.DefaultRematerializationMode = &s
 		}
 
 		// by omission, cache client

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -454,6 +454,9 @@ func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta 
 	wsid, _ := oid.NewOID(data.Get("workspace").(string))
 
 	rematerializationMode := RematerializationModeRematerialize
+	if client.DefaultRematerializationMode != nil {
+		rematerializationMode = TerraformRematerializationMode(toCamel(*client.DefaultRematerializationMode))
+	}
 	if mode, ok := data.GetOk("rematerialization_mode"); ok {
 		rematerializationMode = TerraformRematerializationMode(toCamel(mode.(string)))
 	}


### PR DESCRIPTION
Since some Observe dataset deployments are controlled via Terraform, provide an option to set the default rematerialization policy. The provider-level option will be overridden by those set at the resource-level