### PR TITLE
fix: embed timezone database for validation on systems without timezone data

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	_ "time/tzdata" // Embed timezone database for environments without system tzdata
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/observeinc/terraform-provider-observe/observe"
 )


### PR DESCRIPTION
The time zone "America/Chicago" failed validation on some devices, which i wasn't able to reproduce. My best guess is missing system time zone data.

See https://pkg.go.dev/time/tzdata