### PR TITLE
fix: properly escape URL parts for REST API queries

### DIFF
--- a/client/rest/referencetables.go
+++ b/client/rest/referencetables.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -112,7 +113,7 @@ func (client *Client) CreateReferenceTable(ctx context.Context, input *Reference
 }
 
 func (client *Client) GetReferenceTable(ctx context.Context, id string) (*ReferenceTable, error) {
-	resp, err := client.Get("/v1/referencetables/" + id)
+	resp, err := client.Get("/v1/referencetables/" + url.PathEscape(id))
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +132,7 @@ func (client *Client) UpdateReferenceTable(ctx context.Context, id string, input
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Put("/v1/referencetables/"+id, contentType, body)
+	resp, err := client.Put("/v1/referencetables/"+url.PathEscape(id), contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +150,7 @@ func (client *Client) UpdateReferenceTableMetadata(ctx context.Context, id strin
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Patch("/v1/referencetables/"+id, "application/json", bytes.NewReader(body))
+	resp, err := client.Patch("/v1/referencetables/"+url.PathEscape(id), "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (client *Client) UpdateReferenceTableMetadata(ctx context.Context, id strin
 }
 
 func (client *Client) DeleteReferenceTable(ctx context.Context, id string) error {
-	resp, err := client.Delete("/v1/referencetables/" + id)
+	resp, err := client.Delete("/v1/referencetables/" + url.PathEscape(id))
 	if err != nil {
 		return err
 	}
@@ -172,7 +173,7 @@ func (client *Client) DeleteReferenceTable(ctx context.Context, id string) error
 }
 
 func (client *Client) LookupReferenceTable(ctx context.Context, label string) (*ReferenceTable, error) {
-	resp, err := client.Get("/v1/referencetables?label=" + label)
+	resp, err := client.Get("/v1/referencetables?label=" + url.QueryEscape(label))
 	if err != nil {
 		return nil, err
 	}

--- a/client/rest/reports.go
+++ b/client/rest/reports.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/observeinc/terraform-provider-observe/client/oid"
 )
@@ -102,7 +103,7 @@ func (client *Client) CreateReport(ctx context.Context, req *ReportsDefinition) 
 }
 
 func (client *Client) GetReport(ctx context.Context, id string) (*ReportsResource, error) {
-	resp, err := client.Get("/v1/reports/" + id + "?expand=true")
+	resp, err := client.Get("/v1/reports/" + url.PathEscape(id) + "?expand=true")
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +118,7 @@ func (client *Client) UpdateReport(ctx context.Context, id string, req *ReportsD
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Patch("/v1/reports/"+id+"?expand=true", "application/json", bytes.NewReader(body))
+	resp, err := client.Patch("/v1/reports/"+url.PathEscape(id)+"?expand=true", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +127,7 @@ func (client *Client) UpdateReport(ctx context.Context, id string, req *ReportsD
 }
 
 func (client *Client) DeleteReport(ctx context.Context, id string) error {
-	resp, err := client.Delete("/v1/reports/" + id)
+	resp, err := client.Delete("/v1/reports/" + url.PathEscape(id))
 	if err != nil {
 		return err
 	}

--- a/client/rest/service_accounts.go
+++ b/client/rest/service_accounts.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/observeinc/terraform-provider-observe/client/oid"
 )
@@ -57,7 +58,7 @@ func (client *Client) CreateServiceAccount(ctx context.Context, req *ServiceAcco
 }
 
 func (client *Client) GetServiceAccount(ctx context.Context, id string) (*ServiceAccountResource, error) {
-	resp, err := client.Get("/v1/service-accounts/" + id)
+	resp, err := client.Get("/v1/service-accounts/" + url.PathEscape(id))
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +73,7 @@ func (client *Client) UpdateServiceAccount(ctx context.Context, id string, req *
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Patch("/v1/service-accounts/"+id, "application/json", bytes.NewReader(body))
+	resp, err := client.Patch("/v1/service-accounts/"+url.PathEscape(id), "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +82,7 @@ func (client *Client) UpdateServiceAccount(ctx context.Context, id string, req *
 }
 
 func (client *Client) DeleteServiceAccount(ctx context.Context, id string) error {
-	resp, err := client.Delete("/v1/service-accounts/" + id)
+	resp, err := client.Delete("/v1/service-accounts/" + url.PathEscape(id))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Mainly for looking up reference tables by label, to support spaces in the label. The IDs should generally be url safe already, but escaping them anyway for a better error message if we do somehow get a bad id.

Hopefully will get the generator set up soon after which this won't need to be manually dealt with anymore.