### PR TITLE
OB-49319: Document interval monitor deprecation

### DIFF
--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -44,7 +44,7 @@ data "observe_monitor_v2" "name_lookup" {
 One of `name` or `id` must be set.
 - `name` (String) Monitor name.
 One of `name` or `id` must be set. If `name` is provided, `workspace` must be set.
-- `scheduling` (Block List) Holds information about when the monitor should evaluate. The types of scheduling (interval, transform, and scheduled) are exclusive. If omitted, defaults to transform. (see [below for nested schema](#nestedblock--scheduling))
+- `scheduling` (Block List) Holds information about when the monitor should evaluate. The types of scheduling (transform, scheduled, and interval@deprecated) are exclusive. If omitted, defaults to transform. (see [below for nested schema](#nestedblock--scheduling))
 - `workspace` (String) OID of the workspace this object is contained in.
 
 ### Read-Only
@@ -78,7 +78,9 @@ Optional:
 
 Read-Only:
 
-- `interval` (Block List) Should be used to run explicit ad-hoc queries. (see [below for nested schema](#nestedblock--scheduling--interval))
+- `interval` (Block List) @DEPRECATED: Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
+Recommended to migrate to transform scheduling if the pre-existing interval monitor runs on an accelerable OPAL query.
+Was used to run explicit ad-hoc queries. (see [below for nested schema](#nestedblock--scheduling--interval))
 - `transform` (Block List) Should be used to defer scheduling to the transformer and evaluate when data becomes available. (see [below for nested schema](#nestedblock--scheduling--transform))
 
 <a id="nestedblock--scheduling--scheduled"></a>

--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -78,7 +78,7 @@ Optional:
 
 Read-Only:
 
-- `interval` (Block List) @DEPRECATED: Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
+- `interval` (Block List, Deprecated) Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
 Recommended to migrate to transform scheduling if the pre-existing interval monitor runs on an accelerable OPAL query.
 Was used to run explicit ad-hoc queries. (see [below for nested schema](#nestedblock--scheduling--interval))
 - `transform` (Block List) Should be used to defer scheduling to the transformer and evaluate when data becomes available. (see [below for nested schema](#nestedblock--scheduling--transform))

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -100,7 +100,7 @@ its predecessor. (see [below for nested schema](#nestedblock--stage))
 - `lookback_time` (String) optionally describes a duration that must be satisfied by this monitor. It applies to all rules, but is only applicable to rule kinds that utilize it.
 - `max_alerts_per_hour` (Number) overrides the default value of max alerts generated in a single hour before the monitor is deactivated for safety
 - `no_data_rules` (Block List, Max: 1) No data rules allows a user to be alerted on missing data for the specified lookback window. When provided, the severity is fixed to the NoData severity. As of today, the max number of no data rules that can be created is 1 for the threshold monitor kind. (see [below for nested schema](#nestedblock--no_data_rules))
-- `scheduling` (Block List, Max: 1) Holds information about when the monitor should evaluate. The types of scheduling (interval, transform, and scheduled) are exclusive. If omitted, defaults to transform. (see [below for nested schema](#nestedblock--scheduling))
+- `scheduling` (Block List, Max: 1) Holds information about when the monitor should evaluate. The types of scheduling (transform, scheduled, and interval@deprecated) are exclusive. If omitted, defaults to transform. (see [below for nested schema](#nestedblock--scheduling))
 
 ### Read-Only
 
@@ -633,7 +633,9 @@ Optional:
 
 Optional:
 
-- `interval` (Block List, Max: 1) Should be used to run explicit ad-hoc queries. (see [below for nested schema](#nestedblock--scheduling--interval))
+- `interval` (Block List, Max: 1, Deprecated) @DEPRECATED: Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
+Recommended to migrate to transform scheduling if the pre-existing interval monitor runs on an accelerable OPAL query.
+Was used to run explicit ad-hoc queries. (see [below for nested schema](#nestedblock--scheduling--interval))
 - `scheduled` (Block List, Max: 1) Should be specified to get wall-clock scheduled evaluation. Note: Support for scheduled monitors is currently experimental. (see [below for nested schema](#nestedblock--scheduling--scheduled))
 - `transform` (Block List, Max: 1) Should be used to defer scheduling to the transformer and evaluate when data becomes available. (see [below for nested schema](#nestedblock--scheduling--transform))
 

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -633,7 +633,7 @@ Optional:
 
 Optional:
 
-- `interval` (Block List, Max: 1, Deprecated) @DEPRECATED: Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
+- `interval` (Block List, Max: 1, Deprecated) Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
 Recommended to migrate to transform scheduling if the pre-existing interval monitor runs on an accelerable OPAL query.
 Was used to run explicit ad-hoc queries. (see [below for nested schema](#nestedblock--scheduling--interval))
 - `scheduled` (Block List, Max: 1) Should be specified to get wall-clock scheduled evaluation. Note: Support for scheduled monitors is currently experimental. (see [below for nested schema](#nestedblock--scheduling--scheduled))

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -286,6 +286,7 @@ func dataSourceMonitorV2() *schema.Resource {
 						},
 						"interval": { // MonitorV2IntervalScheduleInput
 							Type:        schema.TypeList,
+							Deprecated:  descriptions.Get("monitorv2", "schema", "scheduling", "interval", "deprecation"),
 							Optional:    true,
 							Computed:    true,
 							Description: descriptions.Get("monitorv2", "schema", "scheduling", "interval", "description"),

--- a/observe/descriptions/monitorv2.yaml
+++ b/observe/descriptions/monitorv2.yaml
@@ -63,7 +63,7 @@ schema:
       deprecation: |
          Interval scheduling is deprecated. Creation of new interval monitors is no longer supported. Use transform or scheduled monitor instead.
       description: |
-        @DEPRECATED: Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
+        Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
         Recommended to migrate to transform scheduling if the pre-existing interval monitor runs on an accelerable OPAL query.
         Was used to run explicit ad-hoc queries.
       interval: |

--- a/observe/descriptions/monitorv2.yaml
+++ b/observe/descriptions/monitorv2.yaml
@@ -58,10 +58,14 @@ schema:
     Describes the groups that logically separate events/rows/etc from each other. If monitor dataset is resource type and monitor strategy is promote, this field should be either empty or only contain the primary keys of the dataset.
   scheduling:
     description: |
-      Holds information about when the monitor should evaluate. The types of scheduling (interval, transform, and scheduled) are exclusive. If omitted, defaults to transform.
+      Holds information about when the monitor should evaluate. The types of scheduling (transform, scheduled, and interval@deprecated) are exclusive. If omitted, defaults to transform.
     interval:
+      deprecation: |
+         Interval scheduling is deprecated. Creation of new interval monitors is no longer supported. Use transform or scheduled monitor instead.
       description: |
-        Should be used to run explicit ad-hoc queries.
+        @DEPRECATED: Creation of new interval monitors is not supported, but existing interval monitors will continue to be supported. 
+        Recommended to migrate to transform scheduling if the pre-existing interval monitor runs on an accelerable OPAL query.
+        Was used to run explicit ad-hoc queries.
       interval: |
         How often the monitor should attempt to run.
       randomize: |

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -296,6 +296,7 @@ func resourceMonitorV2() *schema.Resource {
 						},
 						"interval": { // MonitorV2IntervalScheduleInput
 							Type:          schema.TypeList,
+							Deprecated:    descriptions.Get("monitorv2", "schema", "scheduling", "interval", "deprecation"),
 							Optional:      true,
 							MaxItems:      1,
 							Description:   descriptions.Get("monitorv2", "schema", "scheduling", "interval", "description"),


### PR DESCRIPTION
This is a small change to the documentation informing of the deprecation of the `interval` type monitors. 