### PR TITLE
feat: add support for new RBAC permissions from GraphQL schema

### DIFF
--- a/client/oid/oid.go
+++ b/client/oid/oid.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	oidRegex      = regexp.MustCompile(`o:::(?P<type>[a-z0-9]+):(?P<id>\d+)(/(?P<version>.*))?`)
+	oidRegex      = regexp.MustCompile(`o:::(?P<type>[a-z0-9]+):(?P<id>[\da-f-]+)(/(?P<version>.*))?`)
 	ornRegex      = regexp.MustCompile(`o::(?P<customer>\d+):(?P<type>[a-z]+):(?P<id>\d+)?`)
 	errInvalidOID = errors.New("invalid oid")
 )
@@ -19,6 +19,7 @@ var (
 type Type string
 
 const (
+	TypeAichat                  Type = "aichat"
 	TypeApp                     Type = "app"
 	TypeAppDataSource           Type = "appdatasource"
 	TypeBoard                   Type = "board"
@@ -63,6 +64,7 @@ const (
 
 func (t Type) IsValid() bool {
 	switch t {
+	case TypeAichat:
 	case TypeApp:
 	case TypeAppDataSource:
 	case TypeBoard:

--- a/client/oid/oid_test.go
+++ b/client/oid/oid_test.go
@@ -45,6 +45,13 @@ func TestOid(t *testing.T) {
 				Id:   "o::123458:rbacgroup:8000002523",
 			},
 		},
+		{
+			Input: "o:::aichat:550e8400-e29b-41d4-a716-446655440000",
+			Expect: &OID{
+				Type: TypeAichat,
+				Id:   "550e8400-e29b-41d4-a716-446655440000",
+			},
+		},
 	}
 
 	for _, tt := range testcases {

--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -66,7 +66,7 @@ resource "observe_grant" "everyone_example" {
 ### Required
 
 - `role` (String) The role to grant.
- Accepted values: `administrator`, `apitoken_creator`, `bookmark_manager`, `dashboard_creator`, `dashboard_editor`, `dashboard_viewer`, `dashboard_visibility_editor`, `dataset_accelerator`, `dataset_creator`, `dataset_editor`, `dataset_viewer`, `datastream_creator`, `datastream_editor`, `datastream_viewer`, `investigator_global`, `monitor_creator`, `monitor_editor`, `monitor_viewer`, `monitor_action_creator`, `monitor_global_muter`, `reference_table_creator`, `report_manager`, `service_account_creator`, `user_deleter`, `user_inviter`, `worksheet_creator`, `worksheet_editor`, `worksheet_viewer`, `worksheet_visibility_editor`
+ Accepted values: `administrator`, `aichat_creator`, `aichat_editor`, `aichat_viewer`, `apitoken_creator`, `bookmark_manager`, `dashboard_creator`, `dashboard_editor`, `dashboard_viewer`, `dashboard_visibility_editor`, `dataset_accelerator`, `dataset_creator`, `dataset_editor`, `dataset_viewer`, `datastream_creator`, `datastream_editor`, `datastream_viewer`, `investigator_global`, `monitor_creator`, `monitor_editor`, `monitor_viewer`, `monitor_action_creator`, `monitor_global_muter`, `reference_table_creator`, `report_manager`, `service_account_creator`, `share_in_manager`, `share_in_viewer`, `skill_visibility_editor`, `user_deleter`, `user_inviter`, `worksheet_creator`, `worksheet_editor`, `worksheet_viewer`, `worksheet_visibility_editor`
 - `subject` (String) OID of the subject. Must be a user or a group.
 
 ### Optional

--- a/docs/resources/resource_grants.md
+++ b/docs/resources/resource_grants.md
@@ -81,7 +81,7 @@ resource "observe_resource_grants" "example2" {
 Required:
 
 - `role` (String) The role to grant.
- Accepted values: `administrator`, `apitoken_creator`, `bookmark_manager`, `dashboard_creator`, `dashboard_editor`, `dashboard_viewer`, `dashboard_visibility_editor`, `dataset_accelerator`, `dataset_creator`, `dataset_editor`, `dataset_viewer`, `datastream_creator`, `datastream_editor`, `datastream_viewer`, `investigator_global`, `monitor_creator`, `monitor_editor`, `monitor_viewer`, `monitor_action_creator`, `monitor_global_muter`, `reference_table_creator`, `report_manager`, `service_account_creator`, `user_deleter`, `user_inviter`, `worksheet_creator`, `worksheet_editor`, `worksheet_viewer`, `worksheet_visibility_editor`
+ Accepted values: `administrator`, `aichat_creator`, `aichat_editor`, `aichat_viewer`, `apitoken_creator`, `bookmark_manager`, `dashboard_creator`, `dashboard_editor`, `dashboard_viewer`, `dashboard_visibility_editor`, `dataset_accelerator`, `dataset_creator`, `dataset_editor`, `dataset_viewer`, `datastream_creator`, `datastream_editor`, `datastream_viewer`, `investigator_global`, `monitor_creator`, `monitor_editor`, `monitor_viewer`, `monitor_action_creator`, `monitor_global_muter`, `reference_table_creator`, `report_manager`, `service_account_creator`, `share_in_manager`, `share_in_viewer`, `skill_visibility_editor`, `user_deleter`, `user_inviter`, `worksheet_creator`, `worksheet_editor`, `worksheet_viewer`, `worksheet_visibility_editor`
 - `subject` (String) OID of the subject. Must be a user or a group.
 
 Read-Only:

--- a/observe/resource_grant.go
+++ b/observe/resource_grant.go
@@ -291,6 +291,9 @@ var validGrantRoles []GrantRole
 
 var (
 	Administrator             GrantRole = createGrantRole("Administrator")
+	AichatCreator             GrantRole = createGrantRole("AichatCreator")
+	AichatEditor              GrantRole = createGrantRole("AichatEditor")
+	AichatViewer              GrantRole = createGrantRole("AichatViewer")
 	ApitokenCreator           GrantRole = createGrantRole("ApitokenCreator")
 	BookmarkManager           GrantRole = createGrantRole("BookmarkManager")
 	DashboardCreator          GrantRole = createGrantRole("DashboardCreator")
@@ -313,6 +316,9 @@ var (
 	ReferenceTableCreator     GrantRole = createGrantRole("ReferenceTableCreator")
 	ReportManager             GrantRole = createGrantRole("ReportManager")
 	ServiceAccountCreator     GrantRole = createGrantRole("ServiceAccountCreator")
+	ShareInManager            GrantRole = createGrantRole("ShareInManager")
+	ShareInViewer             GrantRole = createGrantRole("ShareInViewer")
+	SkillVisibilityEditor     GrantRole = createGrantRole("SkillVisibilityEditor")
 	UserDeleter               GrantRole = createGrantRole("UserDeleter")
 	UserInviter               GrantRole = createGrantRole("UserInviter")
 	WorksheetCreator          GrantRole = createGrantRole("WorksheetCreator")
@@ -326,9 +332,9 @@ func createGrantRole(role GrantRole) GrantRole {
 	return role
 }
 
-var createGrantRoles = []GrantRole{DashboardCreator, DatasetCreator, DatastreamCreator, MonitorCreator, WorksheetCreator}
-var editGrantRoles = []GrantRole{DashboardEditor, DatasetEditor, DatastreamEditor, MonitorEditor, WorksheetEditor}
-var viewGrantRoles = []GrantRole{DashboardViewer, DatasetViewer, DatastreamViewer, MonitorViewer, WorksheetViewer}
+var createGrantRoles = []GrantRole{AichatCreator, DashboardCreator, DatasetCreator, DatastreamCreator, MonitorCreator, WorksheetCreator}
+var editGrantRoles = []GrantRole{AichatEditor, DashboardEditor, DatasetEditor, DatastreamEditor, MonitorEditor, WorksheetEditor}
+var viewGrantRoles = []GrantRole{AichatViewer, DashboardViewer, DatasetViewer, DatastreamViewer, MonitorViewer, WorksheetViewer}
 
 // The following GrantRoles directly map to an RbacRole 1:1
 var roleMapping = map[GrantRole]gql.RbacRole{
@@ -342,6 +348,9 @@ var roleMapping = map[GrantRole]gql.RbacRole{
 	ReferenceTableCreator:     gql.RbacRoleReferencetablecreator,
 	ReportManager:             gql.RbacRoleReportmanager,
 	ServiceAccountCreator:     gql.RbacRoleServiceaccountcreator,
+	ShareInManager:            gql.RbacRoleShareinmanager,
+	ShareInViewer:             gql.RbacRoleShareinviewer,
+	SkillVisibilityEditor:     gql.RbacRoleSkillvisibilityeditor,
 	UserDeleter:               gql.RbacRoleUserdelete,
 	UserInviter:               gql.RbacRoleUserinvite,
 	WorksheetVisibilityEditor: gql.RbacRoleWorksheetvisibilityeditor,
@@ -354,9 +363,10 @@ var reverseRoleMapping = func() map[gql.RbacRole]GrantRole {
 	return m
 }()
 
-var validRbacV2Types = []oid.Type{oid.TypeDashboard, oid.TypeDataset, oid.TypeDatastream, oid.TypeMonitor, oid.TypeWorksheet}
+var validRbacV2Types = []oid.Type{oid.TypeAichat, oid.TypeDashboard, oid.TypeDataset, oid.TypeDatastream, oid.TypeMonitor, oid.TypeWorksheet}
 
 var createGrantRoleForType = map[oid.Type]GrantRole{
+	oid.TypeAichat:     AichatCreator,
 	oid.TypeDashboard:  DashboardCreator,
 	oid.TypeDataset:    DatasetCreator,
 	oid.TypeDatastream: DatastreamCreator,
@@ -365,6 +375,7 @@ var createGrantRoleForType = map[oid.Type]GrantRole{
 }
 
 var editGrantRoleForType = map[oid.Type]GrantRole{
+	oid.TypeAichat:     AichatEditor,
 	oid.TypeDashboard:  DashboardEditor,
 	oid.TypeDataset:    DatasetEditor,
 	oid.TypeDatastream: DatastreamEditor,
@@ -373,6 +384,7 @@ var editGrantRoleForType = map[oid.Type]GrantRole{
 }
 
 var viewGrantRoleForType = map[oid.Type]GrantRole{
+	oid.TypeAichat:     AichatViewer,
 	oid.TypeDashboard:  DashboardViewer,
 	oid.TypeDataset:    DatasetViewer,
 	oid.TypeDatastream: DatastreamViewer,
@@ -396,6 +408,8 @@ func (r GrantRole) ToRbacRole() (gql.RbacRole, error) {
 
 func (r GrantRole) ToType() *oid.Type {
 	switch r {
+	case AichatCreator, AichatEditor, AichatViewer:
+		return asPointer(oid.TypeAichat)
 	case DashboardCreator, DashboardEditor, DashboardViewer:
 		return asPointer(oid.TypeDashboard)
 	case DatasetCreator, DatasetEditor, DatasetViewer:

--- a/observe/resource_grant_test.go
+++ b/observe/resource_grant_test.go
@@ -133,6 +133,39 @@ func TestAccObserveGrantEveryoneWorksheetView(t *testing.T) {
 	})
 }
 
+func TestAccObserveGrantGroupAichatView(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(configPreamble+`
+				resource "observe_rbac_group" "example" {
+					name      = "%[1]s"
+				}
+
+				# Uses a hardcoded OID because there is no observe_aichat resource.
+				# Also exercises UUID-based OID parsing (aichat IDs are UUIDs).
+				resource "observe_grant" "example" {
+					subject = observe_rbac_group.example.oid
+					role    = "aichat_viewer"
+					qualifier {
+						oid = "o:::aichat:550e8400-e29b-41d4-a716-446655440000"
+					}
+				}
+				`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("observe_grant.example", "subject"),
+					resource.TestCheckResourceAttr("observe_grant.example", "role", "aichat_viewer"),
+					resource.TestCheckResourceAttr("observe_grant.example", "qualifier.#", "1"),
+					resource.TestCheckResourceAttr("observe_grant.example", "qualifier.0.oid", "o:::aichat:550e8400-e29b-41d4-a716-446655440000"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccObserveGrantGroupAdminWorkspace(t *testing.T) {
 	randomPrefix := acctest.RandomWithPrefix("tf")
 	resource.Test(t, resource.TestCase{

--- a/observe/resource_workspace_default_grants.go
+++ b/observe/resource_workspace_default_grants.go
@@ -24,6 +24,7 @@ var validWorkspaceDefaultGrantPermissions = []WorkspaceDefaultGrantPermission{
 }
 
 var validWorkspaceDefaultGrantObjectTypes = []gql.ORType{
+	gql.ORTypeAichat,
 	gql.ORTypeDashboard,
 	gql.ORTypeDatastream,
 	gql.ORTypeMonitor,


### PR DESCRIPTION
Add grant roles for ShareInManager, ShareInViewer, and SkillVisibilityEditor which map 1:1 to their corresponding RbacRole enum values.

Add Aichat as a new resource type supporting create/edit/view grants (AichatCreator, AichatEditor, AichatViewer) backed by a new oid.TypeAichat. Also add Aichat to workspace default grant object types.