### PR TITLE
Fix log-derived metric dataset docs and input validation

### DIFF
--- a/docs/resources/log_derived_metric_dataset.md
+++ b/docs/resources/log_derived_metric_dataset.md
@@ -202,19 +202,20 @@ resource "observe_log_derived_metric_dataset" "unique_pods" {
 - `input` (String) OID of the source dataset to derive metrics from.
 - `metric_name` (String) The name of the derived metric.
 - `workspace` (String) OID of the workspace this object is contained in.
-This field is optional and deprecated. Since each customer has exactly
-one workspace, the server automatically assigns the correct workspace.
 
 ### Optional
 
 - `description` (String) Dataset description.
 - `icon_url` (String) Icon to be displayed for this object. Icons are sourced from the [fluency-filled](https://icons8.com/icons/fluency-systems-filled) icon set.
-- `interval` (String) Aggregation interval as a duration string (e.g. "1m", "5m").
+- `interval` (String) Aggregation interval as a Go duration string accepted by `time.ParseDuration`
+(for example `30s`, `1m`, `5m`, or `1h`).
 - `metric_tag` (Block List) Tags (dimensions) to attach to the derived metric. Each tag specifies a name and a field path
 identifying the source column. Tags become grouping dimensions on the resulting metric. (see [below for nested schema](#nestedblock--metric_tag))
-- `metric_type` (String) The type of the derived metric, e.g. "gauge", "cumulative_counter", "delta".
-- `shaping_query` (String) An OPAL pipeline applied to the input dataset before aggregation. If omitted or
-empty, rows from the input dataset are aggregated directly.
+- `metric_type` (String) Metric type for the derived metric. Accepted values are `cumulative_counter`,
+`counter`, `rate_per_sec`, `delta`, `gauge`, `tdigest`, `sample`,
+`histogram`, and `exponential_histogram`.
+- `shaping_query` (String) An OPAL pipeline applied to the input dataset before aggregation. Defaults to
+`filter true`, which leaves the input rows unchanged before aggregation.
 - `unit` (String) The unit of the derived metric (e.g. "bytes", "seconds").
 
 ### Read-Only
@@ -228,11 +229,15 @@ should be used when referring to this object in terraform manifests.
 
 Required:
 
-- `function` (String) Aggregation function to apply. One of: count, count_distinct, sum, avg, min, max.
+- `function` (String) Aggregation function to apply. Accepted values are `count`,
+`count_distinct`, `sum`, `avg`, `min`, and `max`.
 
 Optional:
 
-- `field_path` (Block List, Max: 1) Identifies the field to aggregate over. Required for sum, avg, min, max. Must not be set for count or count_distinct. (see [below for nested schema](#nestedblock--aggregation--field_path))
+- `field_path` (Block List, Max: 1) Identifies the field to aggregate over when the selected function operates
+on a specific value. `count` does not use `field_path`;
+`count_distinct`, `sum`, `avg`, `min`, and `max` use it. The exact
+combination is validated during dataset save. (see [below for nested schema](#nestedblock--aggregation--field_path))
 
 <a id="nestedblock--aggregation--field_path"></a>
 ### Nested Schema for `aggregation.field_path`

--- a/observe/descriptions/log_derived_metric_dataset.yaml
+++ b/observe/descriptions/log_derived_metric_dataset.yaml
@@ -8,24 +8,31 @@ schema:
   input: |
     OID of the source dataset to derive metrics from.
   shaping_query: |
-    An OPAL pipeline applied to the input dataset before aggregation. If omitted or
-    empty, rows from the input dataset are aggregated directly.
+    An OPAL pipeline applied to the input dataset before aggregation. Defaults to
+    `filter true`, which leaves the input rows unchanged before aggregation.
   metric_name: |
     The name of the derived metric.
   metric_type: |
-    The type of the derived metric, e.g. "gauge", "cumulative_counter", "delta".
+    Metric type for the derived metric. Accepted values are `cumulative_counter`,
+    `counter`, `rate_per_sec`, `delta`, `gauge`, `tdigest`, `sample`,
+    `histogram`, and `exponential_histogram`.
   unit: |
     The unit of the derived metric (e.g. "bytes", "seconds").
   interval: |
-    Aggregation interval as a duration string (e.g. "1m", "5m").
+    Aggregation interval as a Go duration string accepted by `time.ParseDuration`
+    (for example `30s`, `1m`, `5m`, or `1h`).
   aggregation:
     description: |
       Aggregation configuration for the log-derived metric.
     function: |
-      Aggregation function to apply. One of: count, count_distinct, sum, avg, min, max.
+      Aggregation function to apply. Accepted values are `count`,
+      `count_distinct`, `sum`, `avg`, `min`, and `max`.
     field_path:
       description: |
-        Identifies the field to aggregate over. Required for sum, avg, min, max. Must not be set for count or count_distinct.
+        Identifies the field to aggregate over when the selected function operates
+        on a specific value. `count` does not use `field_path`;
+        `count_distinct`, `sum`, `avg`, `min`, and `max` use it. The exact
+        combination is validated during dataset save.
       column: |
         Column name from the query output to aggregate on.
       path: |

--- a/observe/resource_log_derived_metric_dataset.go
+++ b/observe/resource_log_derived_metric_dataset.go
@@ -35,7 +35,7 @@ func resourceLogDerivedMetricDataset() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: validateOID(oid.TypeWorkspace),
-				Description:      descriptions.Get("common", "schema", "workspace"),
+				Description:      "OID of the workspace this object is contained in.",
 			},
 			"oid": {
 				Type:        schema.TypeString,
@@ -82,7 +82,7 @@ func resourceLogDerivedMetricDataset() *schema.Resource {
 			"input": {
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: validateOID(),
+				ValidateDiagFunc: validateOID(oid.TypeDataset),
 				Description:      descriptions.Get("log_derived_metric_dataset", "schema", "input"),
 			},
 			"shaping_query": {
@@ -206,6 +206,9 @@ func newLDMShapingStageQueryInput(data ResourceReader) (gql.StageQueryInput, dia
 	parsedOID, err := oid.NewOID(inputOIDStr)
 	if err != nil {
 		return gql.StageQueryInput{}, diag.FromErr(fmt.Errorf("input: %w", err))
+	}
+	if parsedOID.Type != oid.TypeDataset {
+		return gql.StageQueryInput{}, diag.Errorf("input: oid type must be %s", oid.TypeDataset)
 	}
 	datasetID := parsedOID.Id
 	if datasetID == "" {

--- a/observe/resource_log_derived_metric_dataset_test.go
+++ b/observe/resource_log_derived_metric_dataset_test.go
@@ -379,6 +379,20 @@ func TestNewLDMShapingStageQueryInput_SingleInput(t *testing.T) {
 	}
 }
 
+func TestNewLDMShapingStageQueryInput_RejectsNonDatasetOID(t *testing.T) {
+	reader := &mockResourceReader{
+		data: map[string]interface{}{
+			"input":         oid.WorkspaceOid("12345").String(),
+			"shaping_query": "filter true",
+		},
+	}
+
+	_, diags := newLDMShapingStageQueryInput(reader)
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics for a non-dataset input OID")
+	}
+}
+
 func TestLogDerivedMetricDatasetToResourceData_PreservesInputOIDVersion(t *testing.T) {
 	const (
 		datasetID   = "12345"
@@ -448,5 +462,16 @@ func TestResourceLogDerivedMetricDatasetOptionalDefaultsAreComputed(t *testing.T
 		if !schema[field].Computed {
 			t.Fatalf("%s should be computed", field)
 		}
+	}
+}
+
+func TestResourceLogDerivedMetricDatasetShapingQueryDefault(t *testing.T) {
+	field := resourceLogDerivedMetricDataset().Schema["shaping_query"]
+
+	if !field.Optional {
+		t.Fatal("shaping_query should be optional")
+	}
+	if got := field.Default.(string); got != "filter true" {
+		t.Fatalf("expected shaping_query default %q, got %q", "filter true", got)
 	}
 }


### PR DESCRIPTION
Align the generated docs with the actual schema and save-time validation so the published field rules match the working examples. Reject non-dataset input OIDs earlier to surface the intended contract during planning.