### PR TITLE
feat(monitor_v2): reconcile anomaly schema to typed algorithm fields

### DIFF
--- a/client/internal/meta/operation/monitorv2.graphql
+++ b/client/internal/meta/operation/monitorv2.graphql
@@ -123,7 +123,6 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
     computationWindow
     valueColumnName
     compareFn
-    numStandardDeviations
     basicAlgorithmTyped {
         numStandardDeviations
     }

--- a/client/internal/meta/operation/monitorv2.graphql
+++ b/client/internal/meta/operation/monitorv2.graphql
@@ -123,6 +123,7 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
     computationWindow
     valueColumnName
     compareFn
+    numStandardDeviations
     basicAlgorithmTyped {
         numStandardDeviations
     }

--- a/client/internal/meta/operation/monitorv2.graphql
+++ b/client/internal/meta/operation/monitorv2.graphql
@@ -123,8 +123,12 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
     computationWindow
     valueColumnName
     compareFn
-    numStandardDeviations
-    basicAlgorithm
+    basicAlgorithmTyped {
+        numStandardDeviations
+    }
+    seasonalAlgorithm {
+        sensitivity
+    }
 }
 
 fragment MonitorV2NoDataRule on MonitorV2NoDataRule {
@@ -306,7 +310,8 @@ fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {
 # @genqlient(for: "MonitorV2AnomalyRuleInput.comparePercentage", omitempty: true)
 # @genqlient(for: "MonitorV2AnomalyRuleInput.compareGroups", omitempty: true)
 # @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.computationWindow", omitempty: true)
-# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithm", omitempty: true)
+# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithmTyped", omitempty: true)
+# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.seasonalAlgorithm", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.linkColumn", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.columnPath", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.correlationTag", omitempty: true)
@@ -363,7 +368,8 @@ fragment MonitorV2 on MonitorV2 {
 # @genqlient(for: "MonitorV2AnomalyRuleInput.comparePercentage", omitempty: true)
 # @genqlient(for: "MonitorV2AnomalyRuleInput.compareGroups", omitempty: true)
 # @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.computationWindow", omitempty: true)
-# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithm", omitempty: true)
+# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithmTyped", omitempty: true)
+# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.seasonalAlgorithm", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.linkColumn", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.columnPath", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.correlationTag", omitempty: true)
@@ -406,7 +412,8 @@ mutation createMonitorV2(
 # @genqlient(for: "MonitorV2AnomalyRuleInput.comparePercentage", omitempty: true)
 # @genqlient(for: "MonitorV2AnomalyRuleInput.compareGroups", omitempty: true)
 # @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.computationWindow", omitempty: true)
-# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithm", omitempty: true)
+# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithmTyped", omitempty: true)
+# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.seasonalAlgorithm", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.linkColumn", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.columnPath", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.correlationTag", omitempty: true)
@@ -485,7 +492,8 @@ mutation saveMonitorV2Relations(
 # @genqlient(for: "MonitorV2AnomalyRuleInput.comparePercentage", omitempty: true)
 # @genqlient(for: "MonitorV2AnomalyRuleInput.compareGroups", omitempty: true)
 # @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.computationWindow", omitempty: true)
-# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithm", omitempty: true)
+# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithmTyped", omitempty: true)
+# @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.seasonalAlgorithm", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.linkColumn", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.columnPath", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.correlationTag", omitempty: true)

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -7250,6 +7250,9 @@ type MonitorV2AnomalyRuleTemplate struct {
 	// CompareFn allows the user to select one of above, below, or above or below standard deviations to be
 	// the bounds the data point has to be out.
 	CompareFn MonitorV2BoundComparisonFunction `json:"compareFn"`
+	// NumStandardDeviations defines how many standard deviations the data point has to be out of bounds to
+	// be marked as a red point. The user gets to choose a standard deviation between 1 to 5.
+	NumStandardDeviations types.Int64Scalar `json:"numStandardDeviations"`
 	// BasicAlgorithmTyped is the typed replacement for the legacy basicAlgorithm JsonObject placeholder
 	// and the preferred way to configure the basic standard-deviation anomaly family. Setting it
 	// selects the same OPAL evaluation path that basicAlgorithm: {} did, so existing alerts behave
@@ -7278,6 +7281,11 @@ func (v *MonitorV2AnomalyRuleTemplate) GetValueColumnName() string { return v.Va
 // GetCompareFn returns MonitorV2AnomalyRuleTemplate.CompareFn, and is useful for accessing the field via an interface.
 func (v *MonitorV2AnomalyRuleTemplate) GetCompareFn() MonitorV2BoundComparisonFunction {
 	return v.CompareFn
+}
+
+// GetNumStandardDeviations returns MonitorV2AnomalyRuleTemplate.NumStandardDeviations, and is useful for accessing the field via an interface.
+func (v *MonitorV2AnomalyRuleTemplate) GetNumStandardDeviations() types.Int64Scalar {
+	return v.NumStandardDeviations
 }
 
 // GetBasicAlgorithmTyped returns MonitorV2AnomalyRuleTemplate.BasicAlgorithmTyped, and is useful for accessing the field via an interface.
@@ -17580,6 +17588,7 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
+	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -21485,6 +21494,7 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
+	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -23291,6 +23301,7 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
+	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -24293,6 +24304,7 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
+	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -24608,6 +24620,7 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
+	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -26566,6 +26579,7 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
+	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -7250,9 +7250,6 @@ type MonitorV2AnomalyRuleTemplate struct {
 	// CompareFn allows the user to select one of above, below, or above or below standard deviations to be
 	// the bounds the data point has to be out.
 	CompareFn MonitorV2BoundComparisonFunction `json:"compareFn"`
-	// NumStandardDeviations defines how many standard deviations the data point has to be out of bounds to
-	// be marked as a red point. The user gets to choose a standard deviation between 1 to 5.
-	NumStandardDeviations types.Int64Scalar `json:"numStandardDeviations"`
 	// BasicAlgorithmTyped is the typed replacement for the legacy basicAlgorithm JsonObject placeholder
 	// and the preferred way to configure the basic standard-deviation anomaly family. Setting it
 	// selects the same OPAL evaluation path that basicAlgorithm: {} did, so existing alerts behave
@@ -7281,11 +7278,6 @@ func (v *MonitorV2AnomalyRuleTemplate) GetValueColumnName() string { return v.Va
 // GetCompareFn returns MonitorV2AnomalyRuleTemplate.CompareFn, and is useful for accessing the field via an interface.
 func (v *MonitorV2AnomalyRuleTemplate) GetCompareFn() MonitorV2BoundComparisonFunction {
 	return v.CompareFn
-}
-
-// GetNumStandardDeviations returns MonitorV2AnomalyRuleTemplate.NumStandardDeviations, and is useful for accessing the field via an interface.
-func (v *MonitorV2AnomalyRuleTemplate) GetNumStandardDeviations() types.Int64Scalar {
-	return v.NumStandardDeviations
 }
 
 // GetBasicAlgorithmTyped returns MonitorV2AnomalyRuleTemplate.BasicAlgorithmTyped, and is useful for accessing the field via an interface.
@@ -17588,7 +17580,6 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -21494,7 +21485,6 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -23301,7 +23291,6 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -24304,7 +24293,6 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -24620,7 +24608,6 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}
@@ -26579,7 +26566,6 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
 	basicAlgorithmTyped {
 		numStandardDeviations
 	}

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -7250,15 +7250,21 @@ type MonitorV2AnomalyRuleTemplate struct {
 	// CompareFn allows the user to select one of above, below, or above or below standard deviations to be
 	// the bounds the data point has to be out.
 	CompareFn MonitorV2BoundComparisonFunction `json:"compareFn"`
-	// NumStandardDeviations defines how many standard deviations the data point has to be out of bounds to
-	// be marked as a red point. The user gets to choose a standard deviation between 1 to 5.
-	NumStandardDeviations types.Int64Scalar `json:"numStandardDeviations"`
-	// BasicAlgorithm makes the monitor use the basic algorithm to evaluate data and fire alerts. For the
-	// computation window of data, it will calculate the average and standard deviations and then determine
-	// whether the new point is out of bound. As of now, it will be of type JsonObject in anticipation to
-	// introduce MonitorV2BasicAnomalyAlgorithm in the future only if the need for special fields appear.
-	// To use the basic algorithm, set this value to an empty object.
-	BasicAlgorithm *types.JsonObject `json:"basicAlgorithm"`
+	// BasicAlgorithmTyped is the typed replacement for the legacy basicAlgorithm JsonObject placeholder
+	// and the preferred way to configure the basic standard-deviation anomaly family. Setting it
+	// selects the same OPAL evaluation path that basicAlgorithm: {} did, so existing alerts behave
+	// identically; new clients should use this field instead. The field is named "basicAlgorithmTyped"
+	// only because the "basicAlgorithm" name is already taken by the deprecated placeholder; once
+	// that placeholder is removed, this field is expected to be renamed to "basicAlgorithm".
+	// Optional so that other algorithms (e.g. seasonal) can be selected by leaving this unset and
+	// supplying their own typed config; the backend requires that exactly one anomaly algorithm be
+	// configured per monitor and rejects basicAlgorithm + basicAlgorithmTyped together.
+	BasicAlgorithmTyped *MonitorV2AnomalyRuleTemplateBasicAlgorithmTypedMonitorV2BasicAlgorithm `json:"basicAlgorithmTyped"`
+	// SeasonalAlgorithm makes the monitor use Prophet-based seasonal forecasting to evaluate data and
+	// fire alerts. The training window is read from the rolled-up monitor dataset and a forecast is
+	// produced for the evaluation window; data points outside the predicted yhat_lower/yhat_upper band
+	// are flagged. Mutually exclusive with basicAlgorithm.
+	SeasonalAlgorithm *MonitorV2AnomalyRuleTemplateSeasonalAlgorithmMonitorV2SeasonalAlgorithm `json:"seasonalAlgorithm"`
 }
 
 // GetComputationWindow returns MonitorV2AnomalyRuleTemplate.ComputationWindow, and is useful for accessing the field via an interface.
@@ -7274,13 +7280,33 @@ func (v *MonitorV2AnomalyRuleTemplate) GetCompareFn() MonitorV2BoundComparisonFu
 	return v.CompareFn
 }
 
-// GetNumStandardDeviations returns MonitorV2AnomalyRuleTemplate.NumStandardDeviations, and is useful for accessing the field via an interface.
-func (v *MonitorV2AnomalyRuleTemplate) GetNumStandardDeviations() types.Int64Scalar {
-	return v.NumStandardDeviations
+// GetBasicAlgorithmTyped returns MonitorV2AnomalyRuleTemplate.BasicAlgorithmTyped, and is useful for accessing the field via an interface.
+func (v *MonitorV2AnomalyRuleTemplate) GetBasicAlgorithmTyped() *MonitorV2AnomalyRuleTemplateBasicAlgorithmTypedMonitorV2BasicAlgorithm {
+	return v.BasicAlgorithmTyped
 }
 
-// GetBasicAlgorithm returns MonitorV2AnomalyRuleTemplate.BasicAlgorithm, and is useful for accessing the field via an interface.
-func (v *MonitorV2AnomalyRuleTemplate) GetBasicAlgorithm() *types.JsonObject { return v.BasicAlgorithm }
+// GetSeasonalAlgorithm returns MonitorV2AnomalyRuleTemplate.SeasonalAlgorithm, and is useful for accessing the field via an interface.
+func (v *MonitorV2AnomalyRuleTemplate) GetSeasonalAlgorithm() *MonitorV2AnomalyRuleTemplateSeasonalAlgorithmMonitorV2SeasonalAlgorithm {
+	return v.SeasonalAlgorithm
+}
+
+// MonitorV2AnomalyRuleTemplateBasicAlgorithmTypedMonitorV2BasicAlgorithm includes the requested fields of the GraphQL type MonitorV2BasicAlgorithm.
+// The GraphQL type's documentation follows.
+//
+// MonitorV2BasicAlgorithm carries the parameters that are specific to the basic standard-deviation
+// based anomaly algorithm. It is referenced by MonitorV2AnomalyRuleTemplate.basicAlgorithmTyped; the
+// legacy top-level numStandardDeviations and JsonObject basicAlgorithm fields remain accepted for
+// backwards compatibility while clients migrate to this typed shape.
+type MonitorV2AnomalyRuleTemplateBasicAlgorithmTypedMonitorV2BasicAlgorithm struct {
+	// NumStandardDeviations defines how many standard deviations the data point has to be out of bounds
+	// to be marked as a red point. Valid values are 1 to 5.
+	NumStandardDeviations types.Int64Scalar `json:"numStandardDeviations"`
+}
+
+// GetNumStandardDeviations returns MonitorV2AnomalyRuleTemplateBasicAlgorithmTypedMonitorV2BasicAlgorithm.NumStandardDeviations, and is useful for accessing the field via an interface.
+func (v *MonitorV2AnomalyRuleTemplateBasicAlgorithmTypedMonitorV2BasicAlgorithm) GetNumStandardDeviations() types.Int64Scalar {
+	return v.NumStandardDeviations
+}
 
 type MonitorV2AnomalyRuleTemplateInput struct {
 	ComputationWindow     *types.DurationScalar            `json:"computationWindow,omitempty"`
@@ -7288,9 +7314,9 @@ type MonitorV2AnomalyRuleTemplateInput struct {
 	ValueColumnName       string                           `json:"valueColumnName"`
 	CompareFn             MonitorV2BoundComparisonFunction `json:"compareFn"`
 	NumStandardDeviations types.Int64Scalar                `json:"numStandardDeviations"`
-	BasicAlgorithm        *types.JsonObject                `json:"basicAlgorithm,omitempty"`
-	BasicAlgorithmTyped   *MonitorV2BasicAlgorithmInput    `json:"basicAlgorithmTyped"`
-	SeasonalAlgorithm     *MonitorV2SeasonalAlgorithmInput `json:"seasonalAlgorithm"`
+	BasicAlgorithm        *types.JsonObject                `json:"basicAlgorithm"`
+	BasicAlgorithmTyped   *MonitorV2BasicAlgorithmInput    `json:"basicAlgorithmTyped,omitempty"`
+	SeasonalAlgorithm     *MonitorV2SeasonalAlgorithmInput `json:"seasonalAlgorithm,omitempty"`
 }
 
 // GetComputationWindow returns MonitorV2AnomalyRuleTemplateInput.ComputationWindow, and is useful for accessing the field via an interface.
@@ -7327,6 +7353,22 @@ func (v *MonitorV2AnomalyRuleTemplateInput) GetBasicAlgorithmTyped() *MonitorV2B
 // GetSeasonalAlgorithm returns MonitorV2AnomalyRuleTemplateInput.SeasonalAlgorithm, and is useful for accessing the field via an interface.
 func (v *MonitorV2AnomalyRuleTemplateInput) GetSeasonalAlgorithm() *MonitorV2SeasonalAlgorithmInput {
 	return v.SeasonalAlgorithm
+}
+
+// MonitorV2AnomalyRuleTemplateSeasonalAlgorithmMonitorV2SeasonalAlgorithm includes the requested fields of the GraphQL type MonitorV2SeasonalAlgorithm.
+// The GraphQL type's documentation follows.
+//
+// MonitorV2SeasonalAlgorithm tunes the Prophet-based seasonal anomaly detector.
+type MonitorV2AnomalyRuleTemplateSeasonalAlgorithmMonitorV2SeasonalAlgorithm struct {
+	// Sensitivity controls how easily the algorithm flags points as anomalous. When omitted
+	// the server defaults to Medium, which mirrors Prophet's own default interval_width of 0.80.
+	// See MonitorV2AnomalySeasonalSensitivity for the exact mapping from tier to interval_width.
+	Sensitivity *MonitorV2AnomalySeasonalSensitivity `json:"sensitivity"`
+}
+
+// GetSensitivity returns MonitorV2AnomalyRuleTemplateSeasonalAlgorithmMonitorV2SeasonalAlgorithm.Sensitivity, and is useful for accessing the field via an interface.
+func (v *MonitorV2AnomalyRuleTemplateSeasonalAlgorithmMonitorV2SeasonalAlgorithm) GetSensitivity() *MonitorV2AnomalySeasonalSensitivity {
+	return v.Sensitivity
 }
 
 // MonitorV2AnomalySeasonalSensitivity is a user-facing tier that maps to Prophet's interval_width
@@ -17538,8 +17580,12 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
-	basicAlgorithm
+	basicAlgorithmTyped {
+		numStandardDeviations
+	}
+	seasonalAlgorithm {
+		sensitivity
+	}
 }
 fragment MonitorV2ThresholdRule on MonitorV2ThresholdRule {
 	compareValues {
@@ -21439,8 +21485,12 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
-	basicAlgorithm
+	basicAlgorithmTyped {
+		numStandardDeviations
+	}
+	seasonalAlgorithm {
+		sensitivity
+	}
 }
 fragment MonitorV2ThresholdRule on MonitorV2ThresholdRule {
 	compareValues {
@@ -23241,8 +23291,12 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
-	basicAlgorithm
+	basicAlgorithmTyped {
+		numStandardDeviations
+	}
+	seasonalAlgorithm {
+		sensitivity
+	}
 }
 fragment MonitorV2ThresholdRule on MonitorV2ThresholdRule {
 	compareValues {
@@ -24239,8 +24293,12 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
-	basicAlgorithm
+	basicAlgorithmTyped {
+		numStandardDeviations
+	}
+	seasonalAlgorithm {
+		sensitivity
+	}
 }
 fragment MonitorV2ThresholdRule on MonitorV2ThresholdRule {
 	compareValues {
@@ -24550,8 +24608,12 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
-	basicAlgorithm
+	basicAlgorithmTyped {
+		numStandardDeviations
+	}
+	seasonalAlgorithm {
+		sensitivity
+	}
 }
 fragment MonitorV2ThresholdRule on MonitorV2ThresholdRule {
 	compareValues {
@@ -26504,8 +26566,12 @@ fragment MonitorV2AnomalyRuleTemplate on MonitorV2AnomalyRuleTemplate {
 	computationWindow
 	valueColumnName
 	compareFn
-	numStandardDeviations
-	basicAlgorithm
+	basicAlgorithmTyped {
+		numStandardDeviations
+	}
+	seasonalAlgorithm {
+		sensitivity
+	}
 }
 fragment MonitorV2ThresholdRule on MonitorV2ThresholdRule {
 	compareValues {

--- a/client/meta/helpers.go
+++ b/client/meta/helpers.go
@@ -140,6 +140,13 @@ var AllMonitorV2BoundComparisonFunctions = []MonitorV2BoundComparisonFunction{
 	MonitorV2BoundComparisonFunctionBelow,
 }
 
+var AllMonitorV2AnomalySeasonalSensitivities = []MonitorV2AnomalySeasonalSensitivity{
+	MonitorV2AnomalySeasonalSensitivityLow,
+	MonitorV2AnomalySeasonalSensitivityMedium,
+	MonitorV2AnomalySeasonalSensitivityHigh,
+	MonitorV2AnomalySeasonalSensitivityVeryhigh,
+}
+
 var AllMonitorV2AlarmLevels = []MonitorV2AlarmLevel{
 	MonitorV2AlarmLevelCritical,
 	MonitorV2AlarmLevelError,

--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -451,6 +451,7 @@ Read-Only:
 - `basic_algorithm` (List of Object) Configures the monitor to use the basic standard-deviation anomaly algorithm. Set num_standard_deviations inside this block to control the threshold. Mutually exclusive with seasonal_algorithm. (see [below for nested schema](#nestedatt--rule_template--anomaly--basic_algorithm))
 - `compare_fn` (String) The bound comparison function (Above, Below, AboveOrBelow) defining which direction(s) of standard deviation to consider out of bounds.
 - `computation_window` (String) The length of the window used to compute the average and the deviation. This value is automatically computed by the backend based on the evaluation window.
+- `num_standard_deviations` (Number, Deprecated) The number of standard deviations a data point must be out of bounds to be marked as anomalous (1 to 5). Prefer setting this inside the `basic_algorithm` block; the top-level field is deprecated.
 - `seasonal_algorithm` (List of Object) Configures the monitor to use Prophet-based seasonal forecasting. Set this block to enable; data points outside the predicted band are flagged. Mutually exclusive with `basic_algorithm`. (see [below for nested schema](#nestedatt--rule_template--anomaly--seasonal_algorithm))
 - `value_column_name` (String) Indicates which of the columns in the input query to apply the basic algorithm and create bounds over.
 

--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -448,7 +448,7 @@ Read-Only:
 
 Read-Only:
 
-- `basic_algorithm` (List of Object) Configures the monitor to use the basic standard-deviation anomaly algorithm. Set this block (with `num_standard_deviations`) to enable; the basic algorithm computes the average and standard deviations over the computation window. Mutually exclusive with `seasonal_algorithm`. (see [below for nested schema](#nestedatt--rule_template--anomaly--basic_algorithm))
+- `basic_algorithm` (List of Object) Configures the monitor to use the basic standard-deviation anomaly algorithm. Set num_standard_deviations inside this block to control the threshold. Mutually exclusive with seasonal_algorithm. (see [below for nested schema](#nestedatt--rule_template--anomaly--basic_algorithm))
 - `compare_fn` (String) The bound comparison function (Above, Below, AboveOrBelow) defining which direction(s) of standard deviation to consider out of bounds.
 - `computation_window` (String) The length of the window used to compute the average and the deviation. This value is automatically computed by the backend based on the evaluation window.
 - `seasonal_algorithm` (List of Object) Configures the monitor to use Prophet-based seasonal forecasting. Set this block to enable; data points outside the predicted band are flagged. Mutually exclusive with `basic_algorithm`. (see [below for nested schema](#nestedatt--rule_template--anomaly--seasonal_algorithm))

--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -448,10 +448,10 @@ Read-Only:
 
 Read-Only:
 
-- `basic_algorithm` (List of Object) Makes the monitor use the basic algorithm. Set to an empty block to enable. The basic algorithm computes the average and standard deviations over the computation window. (see [below for nested schema](#nestedatt--rule_template--anomaly--basic_algorithm))
+- `basic_algorithm` (List of Object) Configures the monitor to use the basic standard-deviation anomaly algorithm. Set this block (with `num_standard_deviations`) to enable; the basic algorithm computes the average and standard deviations over the computation window. Mutually exclusive with `seasonal_algorithm`. (see [below for nested schema](#nestedatt--rule_template--anomaly--basic_algorithm))
 - `compare_fn` (String) The bound comparison function (Above, Below, AboveOrBelow) defining which direction(s) of standard deviation to consider out of bounds.
 - `computation_window` (String) The length of the window used to compute the average and the deviation. This value is automatically computed by the backend based on the evaluation window.
-- `num_standard_deviations` (Number) The number of standard deviations a data point must be out of bounds to be marked as anomalous (1 to 5).
+- `seasonal_algorithm` (List of Object) Configures the monitor to use Prophet-based seasonal forecasting. Set this block to enable; data points outside the predicted band are flagged. Mutually exclusive with `basic_algorithm`. (see [below for nested schema](#nestedatt--rule_template--anomaly--seasonal_algorithm))
 - `value_column_name` (String) Indicates which of the columns in the input query to apply the basic algorithm and create bounds over.
 
 <a id="nestedatt--rule_template--anomaly--basic_algorithm"></a>
@@ -459,6 +459,15 @@ Read-Only:
 
 Read-Only:
 
+- `num_standard_deviations` (Number)
+
+
+<a id="nestedatt--rule_template--anomaly--seasonal_algorithm"></a>
+### Nested Schema for `rule_template.anomaly.seasonal_algorithm`
+
+Read-Only:
+
+- `sensitivity` (String)
 
 
 

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -98,10 +98,11 @@ resource "observe_monitor_v2" "anomaly_example" {
 
   rule_template {
     anomaly {
-      value_column_name       = "A_credits_adhoc_query_sum"
-      compare_fn              = "above"
-      num_standard_deviations = 3
-      basic_algorithm {}
+      value_column_name = "A_credits_adhoc_query_sum"
+      compare_fn        = "above"
+      basic_algorithm {
+        num_standard_deviations = 3
+      }
     }
   }
 
@@ -892,12 +893,13 @@ Optional:
 Required:
 
 - `compare_fn` (String) The bound comparison function (Above, Below, AboveOrBelow) defining which direction(s) of standard deviation to consider out of bounds.
-- `num_standard_deviations` (Number) The number of standard deviations a data point must be out of bounds to be marked as anomalous (1 to 5).
 - `value_column_name` (String) Indicates which of the columns in the input query to apply the basic algorithm and create bounds over.
 
 Optional:
 
-- `basic_algorithm` (Block List, Max: 1) Makes the monitor use the basic algorithm. Set to an empty block to enable. The basic algorithm computes the average and standard deviations over the computation window. (see [below for nested schema](#nestedblock--rule_template--anomaly--basic_algorithm))
+- `basic_algorithm` (Block List, Max: 1) Configures the monitor to use the basic standard-deviation anomaly algorithm. Set this block (with `num_standard_deviations`) to enable; the basic algorithm computes the average and standard deviations over the computation window. Mutually exclusive with `seasonal_algorithm`. (see [below for nested schema](#nestedblock--rule_template--anomaly--basic_algorithm))
+- `num_standard_deviations` (Number, Deprecated) The number of standard deviations a data point must be out of bounds to be marked as anomalous (1 to 5). Prefer setting this inside the `basic_algorithm` block; the top-level field is deprecated.
+- `seasonal_algorithm` (Block List, Max: 1) Configures the monitor to use Prophet-based seasonal forecasting. Set this block to enable; data points outside the predicted band are flagged. Mutually exclusive with `basic_algorithm`. (see [below for nested schema](#nestedblock--rule_template--anomaly--seasonal_algorithm))
 
 Read-Only:
 
@@ -905,6 +907,18 @@ Read-Only:
 
 <a id="nestedblock--rule_template--anomaly--basic_algorithm"></a>
 ### Nested Schema for `rule_template.anomaly.basic_algorithm`
+
+Optional:
+
+- `num_standard_deviations` (Number) The number of standard deviations a data point must be out of bounds to be marked as anomalous (1 to 5). Prefer setting this inside the `basic_algorithm` block; the top-level field is deprecated.
+
+
+<a id="nestedblock--rule_template--anomaly--seasonal_algorithm"></a>
+### Nested Schema for `rule_template.anomaly.seasonal_algorithm`
+
+Optional:
+
+- `sensitivity` (String) How tightly the forecast band hugs the historical signal. Higher tiers produce a narrower band and more anomalies. One of `low`, `medium`, `high`, `very_high`. When unset the backend uses its default tier.
 
 
 

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -897,7 +897,7 @@ Required:
 
 Optional:
 
-- `basic_algorithm` (Block List, Max: 1) Configures the monitor to use the basic standard-deviation anomaly algorithm. Set this block (with `num_standard_deviations`) to enable; the basic algorithm computes the average and standard deviations over the computation window. Mutually exclusive with `seasonal_algorithm`. (see [below for nested schema](#nestedblock--rule_template--anomaly--basic_algorithm))
+- `basic_algorithm` (Block List, Max: 1) Configures the monitor to use the basic standard-deviation anomaly algorithm. Set num_standard_deviations inside this block to control the threshold. Mutually exclusive with seasonal_algorithm. (see [below for nested schema](#nestedblock--rule_template--anomaly--basic_algorithm))
 - `num_standard_deviations` (Number, Deprecated) The number of standard deviations a data point must be out of bounds to be marked as anomalous (1 to 5). Prefer setting this inside the `basic_algorithm` block; the top-level field is deprecated.
 - `seasonal_algorithm` (Block List, Max: 1) Configures the monitor to use Prophet-based seasonal forecasting. Set this block to enable; data points outside the predicted band are flagged. Mutually exclusive with `basic_algorithm`. (see [below for nested schema](#nestedblock--rule_template--anomaly--seasonal_algorithm))
 

--- a/examples/resources/observe_monitor_v2/resource.tf
+++ b/examples/resources/observe_monitor_v2/resource.tf
@@ -80,10 +80,11 @@ resource "observe_monitor_v2" "anomaly_example" {
 
   rule_template {
     anomaly {
-      value_column_name       = "A_credits_adhoc_query_sum"
-      compare_fn              = "above"
-      num_standard_deviations = 3
-      basic_algorithm {}
+      value_column_name = "A_credits_adhoc_query_sum"
+      compare_fn        = "above"
+      basic_algorithm {
+        num_standard_deviations = 3
+      }
     }
   }
 

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -134,16 +134,33 @@ func dataSourceMonitorV2() *schema.Resource {
 										Computed:    true,
 										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "compare_fn"),
 									},
-									"num_standard_deviations": {
-										Type:        schema.TypeInt,
-										Computed:    true,
-										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "num_standard_deviations"),
-									},
 									"basic_algorithm": {
 										Type:        schema.TypeList,
 										Computed:    true,
 										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "basic_algorithm"),
-										Elem:        &schema.Resource{Schema: map[string]*schema.Schema{}},
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"num_standard_deviations": {
+													Type:        schema.TypeInt,
+													Computed:    true,
+													Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "num_standard_deviations"),
+												},
+											},
+										},
+									},
+									"seasonal_algorithm": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "seasonal_algorithm"),
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"sensitivity": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "sensitivity"),
+												},
+											},
+										},
 									},
 								},
 							},

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -134,6 +134,12 @@ func dataSourceMonitorV2() *schema.Resource {
 										Computed:    true,
 										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "compare_fn"),
 									},
+									"num_standard_deviations": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Deprecated:  "Set num_standard_deviations inside the basic_algorithm block instead. This field will be removed in a future version.",
+										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "num_standard_deviations"),
+									},
 									"basic_algorithm": {
 										Type:        schema.TypeList,
 										Computed:    true,

--- a/observe/data_source_monitor_v2_test.go
+++ b/observe/data_source_monitor_v2_test.go
@@ -403,8 +403,9 @@ func TestAccObserveGetIDMonitorV2Anomaly(t *testing.T) {
 							anomaly {
 								value_column_name = "temp_number"
 								compare_fn = "above"
-								num_standard_deviations = 3
-								basic_algorithm {}
+								basic_algorithm {
+									num_standard_deviations = 3
+								}
 							}
 						}
 						no_data_rules {
@@ -430,7 +431,7 @@ func TestAccObserveGetIDMonitorV2Anomaly(t *testing.T) {
 					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "rule_kind", "anomaly"),
 					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "rule_template.0.anomaly.0.value_column_name", "temp_number"),
 					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "rule_template.0.anomaly.0.compare_fn", "above"),
-					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "rule_template.0.anomaly.0.num_standard_deviations", "3"),
+					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "rule_template.0.anomaly.0.basic_algorithm.0.num_standard_deviations", "3"),
 					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "rule_template.0.anomaly.0.basic_algorithm.#", "1"),
 					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "no_data_rules.0.expiration", "30m0s"),
 					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "rules.0.level", "informational"),

--- a/observe/descriptions/monitorv2.yaml
+++ b/observe/descriptions/monitorv2.yaml
@@ -66,9 +66,13 @@ schema:
       compare_fn: |
         The bound comparison function (Above, Below, AboveOrBelow) defining which direction(s) of standard deviation to consider out of bounds.
       num_standard_deviations: |
-        The number of standard deviations a data point must be out of bounds to be marked as anomalous (1 to 5).
+        The number of standard deviations a data point must be out of bounds to be marked as anomalous (1 to 5). Prefer setting this inside the `basic_algorithm` block; the top-level field is deprecated.
       basic_algorithm: |
-        Makes the monitor use the basic algorithm. Set to an empty block to enable. The basic algorithm computes the average and standard deviations over the computation window.
+        Configures the monitor to use the basic standard-deviation anomaly algorithm. Set num_standard_deviations inside this block to control the threshold. Mutually exclusive with seasonal_algorithm.
+      seasonal_algorithm: |
+        Configures the monitor to use Prophet-based seasonal forecasting. Set this block to enable; data points outside the predicted band are flagged. Mutually exclusive with `basic_algorithm`.
+      sensitivity: |
+        How tightly the forecast band hugs the historical signal. Higher tiers produce a narrower band and more anomalies. One of `low`, `medium`, `high`, `very_high`. When unset the backend uses its default tier.
   lookback_time: |
     optionally describes a duration that must be satisfied by this monitor. It applies to all rules, but is only applicable to rule kinds that utilize it.
   data_stabilization_delay: |

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -1247,7 +1247,9 @@ func monitorV2FlattenAnomalyRuleTemplate(gqlTemplate gql.MonitorV2AnomalyRuleTem
 		template["num_standard_deviations"] = nsdu
 	}
 	if gqlTemplate.SeasonalAlgorithm != nil {
-		seasonal := map[string]interface{}{}
+		seasonal := map[string]interface{}{
+			"sensitivity": "",
+		}
 		if gqlTemplate.SeasonalAlgorithm.Sensitivity != nil {
 			seasonal["sensitivity"] = toSnake(string(*gqlTemplate.SeasonalAlgorithm.Sensitivity))
 		}

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -1242,14 +1242,8 @@ func monitorV2FlattenAnomalyRuleTemplate(gqlTemplate gql.MonitorV2AnomalyRuleTem
 		template["basic_algorithm"] = []interface{}{map[string]interface{}{
 			"num_standard_deviations": nsdu,
 		}}
-		template["num_standard_deviations"] = nsdu
-	} else if nsdu := int(gqlTemplate.NumStandardDeviations); nsdu != 0 {
-		// Old monitors stored before basicAlgorithmTyped existed: the backend
-		// returns basicAlgorithmTyped=null and carries the value in the
-		// top-level numStandardDeviations field instead.
-		template["basic_algorithm"] = []interface{}{map[string]interface{}{
-			"num_standard_deviations": nsdu,
-		}}
+		// Populate the deprecated top-level field (Computed) so configs that
+		// still reference rule_template.0.anomaly.0.num_standard_deviations don't drift.
 		template["num_standard_deviations"] = nsdu
 	}
 	if gqlTemplate.SeasonalAlgorithm != nil {

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -25,6 +25,7 @@ func resourceMonitorV2() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: resourceMonitorV2CustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			// needed as input to MonitorV2Create, also part of MonitorV2 struct
 			"workspace": { // ObjectId!
@@ -139,17 +140,57 @@ func resourceMonitorV2() *schema.Resource {
 										DiffSuppressFunc: diffSuppressEnums,
 										Description:      descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "compare_fn"),
 									},
-									"num_standard_deviations": { // Int64!
+									"num_standard_deviations": { // @deprecated in GQL: use basic_algorithm.num_standard_deviations
 										Type:        schema.TypeInt,
-										Required:    true,
-										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "num_standard_deviations"),
-									},
-									"basic_algorithm": { // JsonObject
-										Type:        schema.TypeList,
 										Optional:    true,
-										MaxItems:    1,
-										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "basic_algorithm"),
-										Elem:        &schema.Resource{Schema: map[string]*schema.Schema{}},
+										Computed:    true,
+										Deprecated:  "Set num_standard_deviations inside the basic_algorithm block instead. This field will be removed in a future version.",
+										Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "num_standard_deviations"),
+										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+											// Suppress when basic_algorithm.num_standard_deviations carries the
+											// same value so that migrating from the deprecated top-level field
+											// to the nested block produces no spurious plan changes.
+											nested, _ := d.Get("rule_template.0.anomaly.0.basic_algorithm.0.num_standard_deviations").(int)
+											oldVal := 0
+											fmt.Sscanf(old, "%d", &oldVal)
+											return nested != 0 && nested == oldVal
+										},
+									},
+									"basic_algorithm": { // MonitorV2BasicAlgorithmInput
+										Type:          schema.TypeList,
+										Optional:      true,
+										Computed:      true,
+										MaxItems:      1,
+										Description:   descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "basic_algorithm"),
+										ConflictsWith: []string{"rule_template.0.anomaly.0.seasonal_algorithm"},
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"num_standard_deviations": { // Int64!
+													Type:        schema.TypeInt,
+													Optional:    true,
+													Computed:    true,
+													Description: descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "num_standard_deviations"),
+												},
+											},
+										},
+									},
+									"seasonal_algorithm": { // MonitorV2SeasonalAlgorithmInput
+										Type:          schema.TypeList,
+										Optional:      true,
+										MaxItems:      1,
+										ConflictsWith: []string{"rule_template.0.anomaly.0.basic_algorithm"},
+										Description:   descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "seasonal_algorithm"),
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"sensitivity": { // MonitorV2AnomalySeasonalSensitivity
+													Type:             schema.TypeString,
+													Optional:         true,
+													ValidateDiagFunc: validateEnums(gql.AllMonitorV2AnomalySeasonalSensitivities),
+													DiffSuppressFunc: diffSuppressEnums,
+													Description:      descriptions.Get("monitorv2", "schema", "rule_template", "anomaly", "sensitivity"),
+												},
+											},
+										},
 									},
 								},
 							},
@@ -1151,6 +1192,24 @@ func monitorV2FlattenPromoteRule(gqlPromote gql.MonitorV2PromoteRule) []interfac
 	return []interface{}{promoteRule}
 }
 
+func resourceMonitorV2CustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	// When basic_algorithm is set, at least one source of num_standard_deviations
+	// must be provided. The inner field is preferred; the top-level field is deprecated.
+	if _, ok := d.GetOk("rule_template.0.anomaly.0.basic_algorithm"); ok {
+		nested := d.Get("rule_template.0.anomaly.0.basic_algorithm.0.num_standard_deviations").(int)
+		topLevel := d.Get("rule_template.0.anomaly.0.num_standard_deviations").(int)
+		if nested == 0 && topLevel == 0 {
+			return fmt.Errorf(
+				"at least one of basic_algorithm.num_standard_deviations or " +
+					"num_standard_deviations must be set; " +
+					"prefer basic_algorithm.num_standard_deviations as the top-level " +
+					"field is deprecated and will be removed in a future version",
+			)
+		}
+	}
+	return nil
+}
+
 func monitorV2FlattenAnomalyRule(gqlAnomaly gql.MonitorV2AnomalyRule) []interface{} {
 	anomalyRule := map[string]interface{}{}
 	if gqlAnomaly.ComparePercentage != nil {
@@ -1172,15 +1231,27 @@ func monitorV2FlattenRuleTemplate(gqlRuleTemplate gql.MonitorV2RuleTemplate) []i
 
 func monitorV2FlattenAnomalyRuleTemplate(gqlTemplate gql.MonitorV2AnomalyRuleTemplate) []interface{} {
 	template := map[string]interface{}{
-		"value_column_name":       gqlTemplate.ValueColumnName,
-		"compare_fn":              toSnake(string(gqlTemplate.CompareFn)),
-		"num_standard_deviations": int(gqlTemplate.NumStandardDeviations),
+		"value_column_name": gqlTemplate.ValueColumnName,
+		"compare_fn":        toSnake(string(gqlTemplate.CompareFn)),
 	}
 	if gqlTemplate.ComputationWindow != nil {
 		template["computation_window"] = gqlTemplate.ComputationWindow.String()
 	}
-	if gqlTemplate.BasicAlgorithm != nil {
-		template["basic_algorithm"] = []interface{}{map[string]interface{}{}}
+	if gqlTemplate.BasicAlgorithmTyped != nil {
+		nsdu := int(gqlTemplate.BasicAlgorithmTyped.NumStandardDeviations)
+		template["basic_algorithm"] = []interface{}{map[string]interface{}{
+			"num_standard_deviations": nsdu,
+		}}
+		// Populate the deprecated top-level field (Computed) so configs that
+		// still reference rule_template.0.anomaly.0.num_standard_deviations don't drift.
+		template["num_standard_deviations"] = nsdu
+	}
+	if gqlTemplate.SeasonalAlgorithm != nil {
+		seasonal := map[string]interface{}{}
+		if gqlTemplate.SeasonalAlgorithm.Sensitivity != nil {
+			seasonal["sensitivity"] = toSnake(string(*gqlTemplate.SeasonalAlgorithm.Sensitivity))
+		}
+		template["seasonal_algorithm"] = []interface{}{seasonal}
 	}
 	return []interface{}{template}
 }
@@ -1829,7 +1900,22 @@ func newMonitorV2RuleTemplateInput(path string, data *schema.ResourceData) (rule
 func newMonitorV2AnomalyRuleTemplateInput(path string, data *schema.ResourceData) (template *gql.MonitorV2AnomalyRuleTemplateInput, diags diag.Diagnostics) {
 	valueColumnName := data.Get(fmt.Sprintf("%svalue_column_name", path)).(string)
 	compareFn := gql.MonitorV2BoundComparisonFunction(toCamel(data.Get(fmt.Sprintf("%scompare_fn", path)).(string)))
-	numStdDevs := types.Int64Scalar(data.Get(fmt.Sprintf("%snum_standard_deviations", path)).(int))
+
+	// numStandardDeviations is required by the deployed backend on every
+	// MonitorV2AnomalyRuleTemplateInput regardless of which algorithm family
+	// the monitor uses. For basic monitors we send the user-provided value;
+	// for seasonal monitors the field is unused but still must be present, so
+	// we send a sensible default in range.
+	//
+	// Read from basic_algorithm.num_standard_deviations (canonical) first, then
+	// fall back to the deprecated top-level field for old-style configs that
+	// pair basic_algorithm {} with num_standard_deviations at the anomaly level.
+	numStdDevs := types.Int64Scalar(2)
+	if n := data.Get(fmt.Sprintf("%sbasic_algorithm.0.num_standard_deviations", path)).(int); n != 0 {
+		numStdDevs = types.Int64Scalar(n)
+	} else if n := data.Get(fmt.Sprintf("%snum_standard_deviations", path)).(int); n != 0 {
+		numStdDevs = types.Int64Scalar(n)
+	}
 
 	template = &gql.MonitorV2AnomalyRuleTemplateInput{
 		ValueColumnName:       valueColumnName,
@@ -1837,9 +1923,18 @@ func newMonitorV2AnomalyRuleTemplateInput(path string, data *schema.ResourceData
 		NumStandardDeviations: numStdDevs,
 	}
 
-	if _, ok := data.GetOk(fmt.Sprintf("%sbasic_algorithm", path)); ok {
-		ba := types.JsonObject("{}")
-		template.BasicAlgorithm = &ba
+	if _, ok := data.GetOk(fmt.Sprintf("%sseasonal_algorithm", path)); ok {
+		seasonal := &gql.MonitorV2SeasonalAlgorithmInput{}
+		if raw, ok := data.GetOk(fmt.Sprintf("%sseasonal_algorithm.0.sensitivity", path)); ok {
+			sensitivity := gql.MonitorV2AnomalySeasonalSensitivity(toCamel(raw.(string)))
+			seasonal.Sensitivity = &sensitivity
+		}
+		template.SeasonalAlgorithm = seasonal
+	} else {
+		// Basic algorithm: always write basicAlgorithmTyped to the API.
+		template.BasicAlgorithmTyped = &gql.MonitorV2BasicAlgorithmInput{
+			NumStandardDeviations: numStdDevs,
+		}
 	}
 
 	return template, diags

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -1242,8 +1242,14 @@ func monitorV2FlattenAnomalyRuleTemplate(gqlTemplate gql.MonitorV2AnomalyRuleTem
 		template["basic_algorithm"] = []interface{}{map[string]interface{}{
 			"num_standard_deviations": nsdu,
 		}}
-		// Populate the deprecated top-level field (Computed) so configs that
-		// still reference rule_template.0.anomaly.0.num_standard_deviations don't drift.
+		template["num_standard_deviations"] = nsdu
+	} else if nsdu := int(gqlTemplate.NumStandardDeviations); nsdu != 0 {
+		// Old monitors stored before basicAlgorithmTyped existed: the backend
+		// returns basicAlgorithmTyped=null and carries the value in the
+		// top-level numStandardDeviations field instead.
+		template["basic_algorithm"] = []interface{}{map[string]interface{}{
+			"num_standard_deviations": nsdu,
+		}}
 		template["num_standard_deviations"] = nsdu
 	}
 	if gqlTemplate.SeasonalAlgorithm != nil {

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -1673,6 +1673,46 @@ func TestAccObserveMonitorV2Anomaly(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
+				// Old-style: top-level num_standard_deviations + empty basic_algorithm block.
+				Config: fmt.Sprintf(monitorV2ConfigPreamble+`
+					resource "observe_monitor_v2" "first" {
+						workspace = data.observe_workspace.default.oid
+						rule_kind = "anomaly"
+						name = "%[1]s"
+						lookback_time = "30m"
+						inputs = {
+							"test" = observe_datastream.test.dataset
+						}
+						stage {
+							pipeline = "colmake temp_number:14"
+						}
+						stage {
+							pipeline = "timechart 5m, temp_number:avg(temp_number)"
+						}
+						rule_template {
+							anomaly {
+								value_column_name = "temp_number"
+								compare_fn = "above"
+								num_standard_deviations = 3
+								basic_algorithm {}
+							}
+						}
+						rules {
+							level = "informational"
+							anomaly {
+								compare_percentage = 50
+							}
+						}
+					}
+				`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.num_standard_deviations", "3"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.#", "1"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.0.num_standard_deviations", "3"),
+				),
+			},
+			{
+				// Same old-style config: idempotency check (post-apply plan must be empty).
 				Config: fmt.Sprintf(monitorV2ConfigPreamble+`
 					resource "observe_monitor_v2" "first" {
 						workspace = data.observe_workspace.default.oid
@@ -1711,13 +1751,56 @@ func TestAccObserveMonitorV2Anomaly(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_kind", "anomaly"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.value_column_name", "temp_number"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.compare_fn", "above"),
-					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.num_standard_deviations", "3"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.#", "1"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.0.num_standard_deviations", "3"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.level", "informational"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.anomaly.0.compare_percentage", "50"),
 				),
 			},
 			{
+				// New-style: basic_algorithm { num_standard_deviations } block, same value. Verifies that
+				// switching representation from old-style produces no ongoing state drift
+				// (post-apply plan must be empty).
+				Config: fmt.Sprintf(monitorV2ConfigPreamble+`
+					resource "observe_monitor_v2" "first" {
+						workspace = data.observe_workspace.default.oid
+						rule_kind = "anomaly"
+						name = "%[1]s"
+						lookback_time = "30m"
+						inputs = {
+							"test" = observe_datastream.test.dataset
+						}
+						stage {
+							pipeline = "colmake temp_number:14"
+						}
+						stage {
+							pipeline = "timechart 5m, temp_number:avg(temp_number)"
+						}
+						rule_template {
+							anomaly {
+								value_column_name = "temp_number"
+								compare_fn = "above"
+								basic_algorithm {
+									num_standard_deviations = 3
+								}
+							}
+						}
+						rules {
+							level = "informational"
+							anomaly {
+								compare_percentage = 50
+							}
+						}
+					}
+				`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.0.num_standard_deviations", "3"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.#", "1"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.num_standard_deviations", "3"),
+				),
+			},
+			{
+				// New-style with different values.
 				Config: fmt.Sprintf(monitorV2ConfigPreamble+`
 					resource "observe_monitor_v2" "first" {
 						workspace = data.observe_workspace.default.oid
@@ -1737,8 +1820,9 @@ func TestAccObserveMonitorV2Anomaly(t *testing.T) {
 							anomaly {
 								value_column_name = "temp_number"
 								compare_fn = "above_or_below"
-								num_standard_deviations = 2
-								basic_algorithm {}
+								basic_algorithm {
+									num_standard_deviations = 2
+								}
 							}
 						}
 						rules {
@@ -1761,7 +1845,7 @@ func TestAccObserveMonitorV2Anomaly(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_kind", "anomaly"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.value_column_name", "temp_number"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.compare_fn", "above_or_below"),
-					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.num_standard_deviations", "2"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.0.num_standard_deviations", "2"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.level", "informational"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.anomaly.0.compare_percentage", "25"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.1.level", "warning"),
@@ -1799,8 +1883,9 @@ func TestAccObserveMonitorV2AnomalyWithNoDataRule(t *testing.T) {
 							anomaly {
 								value_column_name = "temp_number"
 								compare_fn = "below"
-								num_standard_deviations = 2
-								basic_algorithm {}
+								basic_algorithm {
+									num_standard_deviations = 2
+								}
 							}
 						}
 						no_data_rules {
@@ -1821,10 +1906,101 @@ func TestAccObserveMonitorV2AnomalyWithNoDataRule(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_kind", "anomaly"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.value_column_name", "temp_number"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.compare_fn", "below"),
-					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.num_standard_deviations", "2"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.0.num_standard_deviations", "2"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "no_data_rules.0.expiration", "30m0s"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.level", "informational"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rules.0.anomaly.0.compare_percentage", "50"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObserveMonitorV2AnomalySeasonal(t *testing.T) {
+	// The CI customer does not yet have the seasonal anomaly capability
+	// enabled, so monitor creation fails with "seasonal anomaly monitors are
+	// not enabled for this customer". Skip until the capability is rolled out
+	// to the test customer.
+	t.Skipf("skipping until seasonal anomaly monitors are enabled for the CI customer")
+	randomPrefix := acctest.RandomWithPrefix("tf")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(monitorV2ConfigPreamble+`
+					resource "observe_monitor_v2" "first" {
+						workspace = data.observe_workspace.default.oid
+						rule_kind = "anomaly"
+						name = "%[1]s"
+						lookback_time = "30m"
+						inputs = {
+							"test" = observe_datastream.test.dataset
+						}
+						stage {
+							pipeline = "colmake temp_number:14"
+						}
+						stage {
+							pipeline = "timechart 5m, temp_number:avg(temp_number)"
+						}
+						rule_template {
+							anomaly {
+								value_column_name = "temp_number"
+								compare_fn = "above_or_below"
+								seasonal_algorithm {
+									sensitivity = "high"
+								}
+							}
+						}
+						rules {
+							level = "informational"
+							anomaly {
+								compare_percentage = 50
+							}
+						}
+					}
+				`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.seasonal_algorithm.#", "1"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.seasonal_algorithm.0.sensitivity", "high"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.basic_algorithm.#", "0"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(monitorV2ConfigPreamble+`
+					resource "observe_monitor_v2" "first" {
+						workspace = data.observe_workspace.default.oid
+						rule_kind = "anomaly"
+						name = "%[1]s"
+						lookback_time = "30m"
+						inputs = {
+							"test" = observe_datastream.test.dataset
+						}
+						stage {
+							pipeline = "colmake temp_number:14"
+						}
+						stage {
+							pipeline = "timechart 5m, temp_number:avg(temp_number)"
+						}
+						rule_template {
+							anomaly {
+								value_column_name = "temp_number"
+								compare_fn = "above_or_below"
+								seasonal_algorithm {}
+							}
+						}
+						rules {
+							level = "informational"
+							anomaly {
+								compare_percentage = 50
+							}
+						}
+					}
+				`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.seasonal_algorithm.#", "1"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "rule_template.0.anomaly.0.seasonal_algorithm.0.sensitivity", ""),
 				),
 			},
 		},

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -1917,11 +1917,6 @@ func TestAccObserveMonitorV2AnomalyWithNoDataRule(t *testing.T) {
 }
 
 func TestAccObserveMonitorV2AnomalySeasonal(t *testing.T) {
-	// The CI customer does not yet have the seasonal anomaly capability
-	// enabled, so monitor creation fails with "seasonal anomaly monitors are
-	// not enabled for this customer". Skip until the capability is rolled out
-	// to the test customer.
-	t.Skipf("skipping until seasonal anomaly monitors are enabled for the CI customer")
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
## Summary

Migrate the anomaly monitor rule template to the typed GraphQL fields the Observe backend now exposes:

- `num_standard_deviations` is nested inside a `basic_algorithm` block and submitted via `basicAlgorithmTyped` rather than the deprecated `basicAlgorithm: JsonObject` placeholder and top-level `numStandardDeviations`.
- A new `seasonal_algorithm` block selects Prophet-based seasonal forecasting, with an optional `sensitivity` tier (`low`, `medium`, `high`, `very_high`).

The two algorithm blocks are mutually exclusive because the backend rejects a monitor configured with both families.

## Test plan

- [ ] `make build` / `go build ./...`
- [ ] `make testacc TESTARGS='-run TestAccObserveMonitorV2Anomaly'` (existing basic-algorithm path)
- [ ] `make testacc TESTARGS='-run TestAccObserveMonitorV2AnomalySeasonal'` (new seasonal path, both with and without `sensitivity`)
- [ ] Confirm an existing TF config that still uses `basic_algorithm` plans clean after upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)