### PR TITLE
feat: deprecate workspace on log_derived_metric_dataset

### DIFF
--- a/docs/resources/log_derived_metric_dataset.md
+++ b/docs/resources/log_derived_metric_dataset.md
@@ -201,7 +201,6 @@ resource "observe_log_derived_metric_dataset" "unique_pods" {
 - `aggregation` (Block List, Min: 1, Max: 1) Aggregation configuration for the log-derived metric. (see [below for nested schema](#nestedblock--aggregation))
 - `input` (String) OID of the source dataset to derive metrics from.
 - `metric_name` (String) The name of the derived metric.
-- `workspace` (String) OID of the workspace this object is contained in.
 
 ### Optional
 
@@ -217,6 +216,9 @@ identifying the source column. Tags become grouping dimensions on the resulting 
 - `shaping_query` (String) An OPAL pipeline applied to the input dataset before aggregation. Defaults to
 `filter true`, which leaves the input rows unchanged before aggregation.
 - `unit` (String) The unit of the derived metric (e.g. "bytes", "seconds").
+- `workspace` (String, Deprecated) OID of the workspace this object is contained in.
+This field is optional and deprecated. Since each customer has exactly
+one workspace, the server automatically assigns the correct workspace.
 
 ### Read-Only
 

--- a/observe/resource_dashboard_link_test.go
+++ b/observe/resource_dashboard_link_test.go
@@ -94,51 +94,44 @@ func TestAccDashboardLinkWithoutFolderOrWorkspace(t *testing.T) {
 	randomPrefix := "tf" + acctest.RandString(20)
 	t.Log("random prefix=", randomPrefix)
 
-	config := fmt.Sprintf(linkConfigPreamble+`
-				resource "observe_folder" "default" {
-					workspace  = data.observe_workspace.default.oid
-					name       = "%[1]s"
-				}
+	config := fmt.Sprintf(`
+		resource "observe_dashboard" "a_to_b" {
+			name     = "%[1]s a"
+			icon_url = "test"
+			stages = <<-EOF
+			[{
+				"pipeline": "filter true",
+				"input": [{
+					"inputName": "kubernetes/metrics/Container Metrics",
+					"inputRole": "Data",
+					"datasetId": "41042989"
+				}]
+			}]
+			EOF
+		}
 
-				resource "observe_dashboard" "a_to_b" {
-					workspace = data.observe_workspace.default.oid
-					name      = "%[1]s a"
-					icon_url  = "test"
-					stages = <<-EOF
-					[{
-						"pipeline": "filter field = \"cpu_usage_core_seconds\"\ncolmake cpu_used: value - lag(value, 1), groupby(clusterUid, namespace, podName, containerName)\ncolmake cpu_used: case(\n cpu_used < 0, value, // stream reset for cumulativeCounter metric\n true, cpu_used)\ncoldrop field, value",
-						"input": [{
-							"inputName": "kubernetes/metrics/Container Metrics",
-							"inputRole": "Data",
-							"datasetId": "41042989"
-						}]
-					}]
-					EOF
-				}
+		resource "observe_dashboard" "b_to_a" {
+			name     = "%[1]s b"
+			icon_url = "test"
+			stages = <<-EOF
+			[{
+				"pipeline": "filter true",
+				"input": [{
+					"inputName": "kubernetes/metrics/Container Metrics",
+					"inputRole": "Data",
+					"datasetId": "41042989"
+				}]
+			}]
+			EOF
+		}
 
-				resource "observe_dashboard" "b_to_a" {
-					workspace = data.observe_workspace.default.oid
-					name      = "%[1]s b"
-					icon_url  = "test"
-					stages = <<-EOF
-					[{
-						"pipeline": "filter field = \"cpu_usage_core_seconds\"\ncolmake cpu_used: value - lag(value, 1), groupby(clusterUid, namespace, podName, containerName)\ncolmake cpu_used: case(\n cpu_used < 0, value, // stream reset for cumulativeCounter metric\n true, cpu_used)\ncoldrop field, value",
-						"input": [{
-							"inputName": "kubernetes/metrics/Container Metrics",
-							"inputRole": "Data",
-							"datasetId": "41042989"
-						}]
-					}]
-					EOF
-				}
-
-				resource "observe_dashboard_link" "example_without_folder_or_workspace" {
-					name           = "%[1]s Link (Folder)"
-					description    = "Very linked, much dashboard"
-					from_dashboard = observe_dashboard.a_to_b.oid
-					to_dashboard   = observe_dashboard.b_to_a.oid
-					link_label     = "going nowhere"
-				}`, randomPrefix)
+		resource "observe_dashboard_link" "example_without_folder_or_workspace" {
+			name           = "%[1]s Link"
+			description    = "Very linked, much dashboard"
+			from_dashboard = observe_dashboard.a_to_b.oid
+			to_dashboard   = observe_dashboard.b_to_a.oid
+			link_label     = "going nowhere"
+		}`, randomPrefix)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -147,7 +140,6 @@ func TestAccDashboardLinkWithoutFolderOrWorkspace(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("observe_dashboard_link.example_without_folder_or_workspace", "workspace"),
 					resource.TestCheckResourceAttrSet("observe_dashboard_link.example_without_folder_or_workspace", "folder"),
 					resource.TestCheckResourceAttr("observe_dashboard_link.example_without_folder_or_workspace", "description", "Very linked, much dashboard"),
 					resource.TestCheckResourceAttr("observe_dashboard_link.example_without_folder_or_workspace", "link_label", "going nowhere"),

--- a/observe/resource_log_derived_metric_dataset.go
+++ b/observe/resource_log_derived_metric_dataset.go
@@ -32,10 +32,12 @@ func resourceLogDerivedMetricDataset() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"workspace": {
 				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
+				Optional:         true,
+				Computed:         true,
 				ValidateDiagFunc: validateOID(oid.TypeWorkspace),
-				Description:      "OID of the workspace this object is contained in.",
+				DiffSuppressFunc: diffSuppressWorkspace,
+				Deprecated:       "workspace is no longer required and will be ignored. It may be removed in a future version.",
+				Description:      descriptions.Get("common", "schema", "workspace"),
 			},
 			"oid": {
 				Type:        schema.TypeString,
@@ -184,7 +186,10 @@ func validateLogDerivedMetricDatasetChanges(ctx context.Context, d *schema.Resou
 		return nil
 	}
 
-	wsid, _ := oid.NewOID(d.Get("workspace").(string))
+	wsid, err := client.ResolveWorkspaceID(ctx, maybeString(d.GetOk("workspace")))
+	if err != nil {
+		return fmt.Errorf("failed to resolve workspace: %w", err)
+	}
 	input, _, logInput, diags := newLogDerivedMetricDatasetConfig(d)
 	if diags.HasError() {
 		return fmt.Errorf("invalid log-derived metric dataset config: %s", concatenateDiagnosticsToStr(diags))
@@ -193,7 +198,7 @@ func validateLogDerivedMetricDatasetChanges(ctx context.Context, d *schema.Resou
 		input.Id = &id
 	}
 
-	_, err := client.SaveLogDerivedMetricDatasetDryRun(ctx, wsid.Id, input, logInput)
+	_, err = client.SaveLogDerivedMetricDatasetDryRun(ctx, wsid, input, logInput)
 	if err != nil {
 		return fmt.Errorf("log-derived metric dataset save dry-run failed: %s", err.Error())
 	}
@@ -445,8 +450,11 @@ func resourceLogDerivedMetricDatasetCreate(ctx context.Context, data *schema.Res
 		return diags
 	}
 
-	wsid, _ := oid.NewOID(data.Get("workspace").(string))
-	result, err := client.SaveLogDerivedMetricDataset(ctx, wsid.Id, input, logInput, gql.DefaultDependencyHandling())
+	wsid, err := client.ResolveWorkspaceID(ctx, maybeString(data.GetOk("workspace")))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	result, err := client.SaveLogDerivedMetricDataset(ctx, wsid, input, logInput, gql.DefaultDependencyHandling())
 	if err != nil {
 		return diag.Errorf("failed to create log-derived metric dataset: %s", err)
 	}
@@ -477,9 +485,12 @@ func resourceLogDerivedMetricDatasetUpdate(ctx context.Context, data *schema.Res
 
 	id := data.Id()
 	input.Id = &id
-	wsid, _ := oid.NewOID(data.Get("workspace").(string))
+	wsid, err := client.ResolveWorkspaceID(ctx, maybeString(data.GetOk("workspace")))
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	result, err := client.SaveLogDerivedMetricDataset(ctx, wsid.Id, input, logInput, gql.DefaultDependencyHandling())
+	result, err := client.SaveLogDerivedMetricDataset(ctx, wsid, input, logInput, gql.DefaultDependencyHandling())
 	if err != nil {
 		return diag.Errorf("failed to update log-derived metric dataset: %s", err)
 	}

--- a/observe/workspace_no_ws_resources_test.go
+++ b/observe/workspace_no_ws_resources_test.go
@@ -117,6 +117,35 @@ func TestAccObserveDropFilterNoWorkspace(t *testing.T) {
 	})
 }
 
+func TestAccObserveLogDerivedMetricDatasetNoWorkspace(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+	config := fmt.Sprintf(datastreamNoWorkspacePreamble+`
+		resource "observe_log_derived_metric_dataset" "no_ws" {
+			description = "no workspace test"
+			metric_name = "error_count"
+			metric_type = "gauge"
+			unit        = "1"
+			interval    = "1m"
+			input       = observe_datastream.test_no_ws.dataset
+
+			aggregation {
+				function = "count"
+			}
+		}`, randomPrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: testAccNoWorkspaceSteps(config,
+			resource.TestCheckResourceAttr("observe_log_derived_metric_dataset.no_ws", "description", "no workspace test"),
+			resource.TestCheckResourceAttr("observe_log_derived_metric_dataset.no_ws", "metric_name", "error_count"),
+			resource.TestCheckResourceAttr("observe_log_derived_metric_dataset.no_ws", "metric_type", "gauge"),
+			resource.TestCheckResourceAttr("observe_log_derived_metric_dataset.no_ws", "aggregation.0.function", "count"),
+			resource.TestCheckResourceAttrSet("observe_log_derived_metric_dataset.no_ws", "oid"),
+		),
+	})
+}
+
 func TestAccObserveLinkNoWorkspace(t *testing.T) {
 	randomPrefix := acctest.RandomWithPrefix("tf")
 	config := fmt.Sprintf(linkConfigNoWorkspacePreamble(randomPrefix)+`


### PR DESCRIPTION
## Summary
- Make `workspace` optional and deprecated on `observe_log_derived_metric_dataset`, using `ResolveWorkspaceID` in create, update, and customize-diff dry-run paths.
- Add `TestAccObserveLogDerivedMetricDatasetNoWorkspace` to the no-workspace acceptance suite.
- Refactor `TestAccDashboardLinkWithoutFolderOrWorkspace` to remove `configPreamble`/workspace from parent dashboards and stop asserting the deprecated `workspace` attribute.
- Regenerate docs so `workspace` is listed under Optional (Deprecated).

## Test plan
- [ ] `go test ./observe/ -run LogDerivedMetric -count=1`
- [ ] `TF_ACC=1 go test ./observe/ -run 'LogDerivedMetricDatasetNoWorkspace|DashboardLinkWithoutFolderOrWorkspace' -timeout 60m -v`
- [ ] CI acceptance suite (`make testacc`)


Made with [Cursor](https://cursor.com)