### PR TITLE
feat(monitor_v2): support service bindings

### DIFF
--- a/client/internal/meta/operation/monitorv2.graphql
+++ b/client/internal/meta/operation/monitorv2.graphql
@@ -30,6 +30,10 @@ fragment MonitorV2LinkColumn on MonitorV2LinkColumn {
     }
 }
 
+fragment MonitorV2CorrelationTag on MonitorV2CorrelationTag {
+    tag
+}
+
 fragment MonitorV2Column on MonitorV2Column {
     # @genqlient(flatten: true)
     linkColumn {
@@ -38,6 +42,30 @@ fragment MonitorV2Column on MonitorV2Column {
     # @genqlient(flatten: true)
     columnPath {
         ...MonitorV2ColumnPath
+    }
+    # @genqlient(flatten: true)
+    correlationTag {
+        ...MonitorV2CorrelationTag
+    }
+}
+
+fragment MonitorV2ServiceBindingValue on MonitorV2ServiceBindingValue {
+    value
+    matchMode
+}
+
+fragment MonitorV2ServiceBinding on MonitorV2ServiceBinding {
+    # @genqlient(flatten: true)
+    serviceName {
+        ...MonitorV2ServiceBindingValue
+    }
+    # @genqlient(flatten: true)
+    environment {
+        ...MonitorV2ServiceBindingValue
+    }
+    # @genqlient(flatten: true)
+    serviceNamespace {
+        ...MonitorV2ServiceBindingValue
     }
 }
 
@@ -170,6 +198,10 @@ fragment MonitorV2Definition on MonitorV2Definition{
         ...MonitorV2Scheduling
     }
     customVariables
+    # @genqlient(flatten: true)
+    serviceBindings {
+        ...MonitorV2ServiceBinding
+    }
 }
 
 fragment MonitorV2IntervalSchedule on MonitorV2IntervalSchedule {
@@ -277,6 +309,7 @@ fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {
 # @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithm", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.linkColumn", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.columnPath", omitempty: true)
+# @genqlient(for: "MonitorV2ColumnInput.correlationTag", omitempty: true)
 # @genqlient(for: "MonitorV2LinkColumnInput.meta", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnPathInput.path", omitempty: true)
 # @genqlient(for: "InputDefinitionInput.stageID", omitempty: true)
@@ -333,6 +366,7 @@ fragment MonitorV2 on MonitorV2 {
 # @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithm", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.linkColumn", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.columnPath", omitempty: true)
+# @genqlient(for: "MonitorV2ColumnInput.correlationTag", omitempty: true)
 # @genqlient(for: "MonitorV2LinkColumnInput.meta", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnPathInput.path", omitempty: true)
 # @genqlient(for: "InputDefinitionInput.stageID", omitempty: true)
@@ -375,6 +409,7 @@ mutation createMonitorV2(
 # @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithm", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.linkColumn", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.columnPath", omitempty: true)
+# @genqlient(for: "MonitorV2ColumnInput.correlationTag", omitempty: true)
 # @genqlient(for: "MonitorV2LinkColumnInput.meta", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnPathInput.path", omitempty: true)
 # @genqlient(for: "InputDefinitionInput.stageID", omitempty: true)
@@ -453,6 +488,7 @@ mutation saveMonitorV2Relations(
 # @genqlient(for: "MonitorV2AnomalyRuleTemplateInput.basicAlgorithm", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.linkColumn", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnInput.columnPath", omitempty: true)
+# @genqlient(for: "MonitorV2ColumnInput.correlationTag", omitempty: true)
 # @genqlient(for: "MonitorV2LinkColumnInput.meta", omitempty: true)
 # @genqlient(for: "MonitorV2ColumnPathInput.path", omitempty: true)
 # @genqlient(for: "InputDefinitionInput.stageID", omitempty: true)

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -7379,6 +7379,8 @@ type MonitorV2Column struct {
 	LinkColumn *MonitorV2LinkColumn `json:"linkColumn"`
 	// Column path is any non-link typed column along with an optional path which the user wants to group by.
 	ColumnPath *MonitorV2ColumnPath `json:"columnPath"`
+	// Marks this column as a correlation-tag grouping (e.g. #service.name); mutually exclusive with linkColumn / columnPath. Resolved (tag, column) pair lands on MonitorV2AlertSchema.correlationTags at save time.
+	CorrelationTag *MonitorV2CorrelationTag `json:"correlationTag"`
 }
 
 // GetLinkColumn returns MonitorV2Column.LinkColumn, and is useful for accessing the field via an interface.
@@ -7386,6 +7388,9 @@ func (v *MonitorV2Column) GetLinkColumn() *MonitorV2LinkColumn { return v.LinkCo
 
 // GetColumnPath returns MonitorV2Column.ColumnPath, and is useful for accessing the field via an interface.
 func (v *MonitorV2Column) GetColumnPath() *MonitorV2ColumnPath { return v.ColumnPath }
+
+// GetCorrelationTag returns MonitorV2Column.CorrelationTag, and is useful for accessing the field via an interface.
+func (v *MonitorV2Column) GetCorrelationTag() *MonitorV2CorrelationTag { return v.CorrelationTag }
 
 // MonitorV2ColumnComparison includes the GraphQL fields of MonitorV2ColumnComparison requested by the fragment MonitorV2ColumnComparison.
 type MonitorV2ColumnComparison struct {
@@ -7425,7 +7430,7 @@ func (v *MonitorV2ColumnComparisonInput) GetOperator() *MonitorV2BooleanOperator
 type MonitorV2ColumnInput struct {
 	LinkColumn     *MonitorV2LinkColumnInput     `json:"linkColumn,omitempty"`
 	ColumnPath     *MonitorV2ColumnPathInput     `json:"columnPath,omitempty"`
-	CorrelationTag *MonitorV2CorrelationTagInput `json:"correlationTag"`
+	CorrelationTag *MonitorV2CorrelationTagInput `json:"correlationTag,omitempty"`
 }
 
 // GetLinkColumn returns MonitorV2ColumnInput.LinkColumn, and is useful for accessing the field via an interface.
@@ -7563,6 +7568,16 @@ func (v *MonitorV2ComparisonTermInput) GetComparison() MonitorV2ComparisonInput 
 // GetColumn returns MonitorV2ComparisonTermInput.Column, and is useful for accessing the field via an interface.
 func (v *MonitorV2ComparisonTermInput) GetColumn() MonitorV2ColumnInput { return v.Column }
 
+// MonitorV2CorrelationTag includes the GraphQL fields of MonitorV2CorrelationTag requested by the fragment MonitorV2CorrelationTag.
+type MonitorV2CorrelationTag struct {
+	// The correlation tag name, e.g. "service.name". The leading '#' is implied and
+	// must not be included.
+	Tag string `json:"tag"`
+}
+
+// GetTag returns MonitorV2CorrelationTag.Tag, and is useful for accessing the field via an interface.
+func (v *MonitorV2CorrelationTag) GetTag() string { return v.Tag }
+
 type MonitorV2CorrelationTagInput struct {
 	Tag string `json:"tag"`
 }
@@ -7694,6 +7709,21 @@ type MonitorV2Definition struct {
 	// note: These are distinctly different than the action fragments, which are treated as
 	// mustache partials.
 	CustomVariables *types.JsonObject `json:"customVariables"`
+	// ServiceBindings declares the (serviceName, environment, serviceNamespace) triplets a monitor's
+	// alarms should be attributed to. The list shape is
+	// kept for forward-compatibility; today at most one binding entry is supported.
+	// Optional: when omitted/empty the monitor has no service binding and alarms are
+	// written with NULL service / environment / namespace columns.
+	//
+	// Validation rules (enforced at save time, gated by the service-monitoring feature flag):
+	//
+	// 1. At most one binding entry.
+	// 2. For each wildcard component in the binding, the monitor must supply a
+	// backing column for the corresponding correlation tag - either via an
+	// explicit MonitorV2Column.correlationTag grouping, or via a column-path
+	// grouping that is itself tagged with the matching correlation tag on the
+	// input dataset.
+	ServiceBindings []MonitorV2ServiceBinding `json:"serviceBindings"`
 }
 
 // GetInputQuery returns MonitorV2Definition.InputQuery, and is useful for accessing the field via an interface.
@@ -7729,6 +7759,11 @@ func (v *MonitorV2Definition) GetScheduling() *MonitorV2Scheduling { return v.Sc
 
 // GetCustomVariables returns MonitorV2Definition.CustomVariables, and is useful for accessing the field via an interface.
 func (v *MonitorV2Definition) GetCustomVariables() *types.JsonObject { return v.CustomVariables }
+
+// GetServiceBindings returns MonitorV2Definition.ServiceBindings, and is useful for accessing the field via an interface.
+func (v *MonitorV2Definition) GetServiceBindings() []MonitorV2ServiceBinding {
+	return v.ServiceBindings
+}
 
 type MonitorV2DefinitionInput struct {
 	InputQuery             MultiStageQueryInput           `json:"inputQuery"`
@@ -8239,6 +8274,27 @@ func (v *MonitorV2SeasonalAlgorithmInput) GetSensitivity() *MonitorV2AnomalySeas
 	return v.Sensitivity
 }
 
+// MonitorV2ServiceBinding includes the GraphQL fields of MonitorV2ServiceBinding requested by the fragment MonitorV2ServiceBinding.
+type MonitorV2ServiceBinding struct {
+	// Service-name dimension of the binding.
+	ServiceName MonitorV2ServiceBindingValue `json:"serviceName"`
+	// Environment dimension of the binding.
+	Environment MonitorV2ServiceBindingValue `json:"environment"`
+	// Namespace dimension of the binding.
+	ServiceNamespace MonitorV2ServiceBindingValue `json:"serviceNamespace"`
+}
+
+// GetServiceName returns MonitorV2ServiceBinding.ServiceName, and is useful for accessing the field via an interface.
+func (v *MonitorV2ServiceBinding) GetServiceName() MonitorV2ServiceBindingValue { return v.ServiceName }
+
+// GetEnvironment returns MonitorV2ServiceBinding.Environment, and is useful for accessing the field via an interface.
+func (v *MonitorV2ServiceBinding) GetEnvironment() MonitorV2ServiceBindingValue { return v.Environment }
+
+// GetServiceNamespace returns MonitorV2ServiceBinding.ServiceNamespace, and is useful for accessing the field via an interface.
+func (v *MonitorV2ServiceBinding) GetServiceNamespace() MonitorV2ServiceBindingValue {
+	return v.ServiceNamespace
+}
+
 type MonitorV2ServiceBindingInput struct {
 	// Service-name dimension of the binding.
 	ServiceName MonitorV2ServiceBindingValueInput `json:"serviceName"`
@@ -8273,6 +8329,24 @@ const (
 	MonitorV2ServiceBindingMatchModeExact    MonitorV2ServiceBindingMatchMode = "Exact"
 	MonitorV2ServiceBindingMatchModeWildcard MonitorV2ServiceBindingMatchMode = "Wildcard"
 )
+
+// MonitorV2ServiceBindingValue includes the GraphQL fields of MonitorV2ServiceBindingValue requested by the fragment MonitorV2ServiceBindingValue.
+type MonitorV2ServiceBindingValue struct {
+	// Literal value this dimension matches; null when matchMode is Wildcard.
+	Value *string `json:"value"`
+	// How this dimension is matched. Exact matches value; Wildcard matches any value,
+	// with the concrete value resolved from the monitor's groupings (or the input
+	// dataset's correlation-tag mappings) at detection time.
+	MatchMode *MonitorV2ServiceBindingMatchMode `json:"matchMode"`
+}
+
+// GetValue returns MonitorV2ServiceBindingValue.Value, and is useful for accessing the field via an interface.
+func (v *MonitorV2ServiceBindingValue) GetValue() *string { return v.Value }
+
+// GetMatchMode returns MonitorV2ServiceBindingValue.MatchMode, and is useful for accessing the field via an interface.
+func (v *MonitorV2ServiceBindingValue) GetMatchMode() *MonitorV2ServiceBindingMatchMode {
+	return v.MatchMode
+}
 
 type MonitorV2ServiceBindingValueInput struct {
 	// Exact value to match. For a wildcard, leave this null and set matchMode: Wildcard.
@@ -17353,6 +17427,9 @@ fragment MonitorV2Definition on MonitorV2Definition {
 		... MonitorV2Scheduling
 	}
 	customVariables
+	serviceBindings {
+		... MonitorV2ServiceBinding
+	}
 }
 fragment MonitorV2ActionRule on MonitorV2ActionRule {
 	actionID
@@ -17415,6 +17492,9 @@ fragment MonitorV2Column on MonitorV2Column {
 	columnPath {
 		... MonitorV2ColumnPath
 	}
+	correlationTag {
+		... MonitorV2CorrelationTag
+	}
 }
 fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	interval {
@@ -17425,6 +17505,17 @@ fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	}
 	scheduled {
 		... MonitorV2CronSchedule
+	}
+}
+fragment MonitorV2ServiceBinding on MonitorV2ServiceBinding {
+	serviceName {
+		... MonitorV2ServiceBindingValue
+	}
+	environment {
+		... MonitorV2ServiceBindingValue
+	}
+	serviceNamespace {
+		... MonitorV2ServiceBindingValue
 	}
 }
 fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
@@ -17489,6 +17580,9 @@ fragment MonitorV2ColumnPath on MonitorV2ColumnPath {
 	name
 	path
 }
+fragment MonitorV2CorrelationTag on MonitorV2CorrelationTag {
+	tag
+}
 fragment MonitorV2IntervalSchedule on MonitorV2IntervalSchedule {
 	interval
 	randomize
@@ -17500,6 +17594,10 @@ fragment MonitorV2CronSchedule on MonitorV2CronSchedule {
 	rawCron
 	timezone
 	alarmMode
+}
+fragment MonitorV2ServiceBindingValue on MonitorV2ServiceBindingValue {
+	value
+	matchMode
 }
 fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {
 	comparison {
@@ -21230,6 +21328,9 @@ fragment MonitorV2Definition on MonitorV2Definition {
 		... MonitorV2Scheduling
 	}
 	customVariables
+	serviceBindings {
+		... MonitorV2ServiceBinding
+	}
 }
 fragment MonitorV2ActionRule on MonitorV2ActionRule {
 	actionID
@@ -21292,6 +21393,9 @@ fragment MonitorV2Column on MonitorV2Column {
 	columnPath {
 		... MonitorV2ColumnPath
 	}
+	correlationTag {
+		... MonitorV2CorrelationTag
+	}
 }
 fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	interval {
@@ -21302,6 +21406,17 @@ fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	}
 	scheduled {
 		... MonitorV2CronSchedule
+	}
+}
+fragment MonitorV2ServiceBinding on MonitorV2ServiceBinding {
+	serviceName {
+		... MonitorV2ServiceBindingValue
+	}
+	environment {
+		... MonitorV2ServiceBindingValue
+	}
+	serviceNamespace {
+		... MonitorV2ServiceBindingValue
 	}
 }
 fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
@@ -21366,6 +21481,9 @@ fragment MonitorV2ColumnPath on MonitorV2ColumnPath {
 	name
 	path
 }
+fragment MonitorV2CorrelationTag on MonitorV2CorrelationTag {
+	tag
+}
 fragment MonitorV2IntervalSchedule on MonitorV2IntervalSchedule {
 	interval
 	randomize
@@ -21377,6 +21495,10 @@ fragment MonitorV2CronSchedule on MonitorV2CronSchedule {
 	rawCron
 	timezone
 	alarmMode
+}
+fragment MonitorV2ServiceBindingValue on MonitorV2ServiceBindingValue {
+	value
+	matchMode
 }
 fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {
 	comparison {
@@ -23008,6 +23130,9 @@ fragment MonitorV2Definition on MonitorV2Definition {
 		... MonitorV2Scheduling
 	}
 	customVariables
+	serviceBindings {
+		... MonitorV2ServiceBinding
+	}
 }
 fragment MonitorV2ActionRule on MonitorV2ActionRule {
 	actionID
@@ -23070,6 +23195,9 @@ fragment MonitorV2Column on MonitorV2Column {
 	columnPath {
 		... MonitorV2ColumnPath
 	}
+	correlationTag {
+		... MonitorV2CorrelationTag
+	}
 }
 fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	interval {
@@ -23080,6 +23208,17 @@ fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	}
 	scheduled {
 		... MonitorV2CronSchedule
+	}
+}
+fragment MonitorV2ServiceBinding on MonitorV2ServiceBinding {
+	serviceName {
+		... MonitorV2ServiceBindingValue
+	}
+	environment {
+		... MonitorV2ServiceBindingValue
+	}
+	serviceNamespace {
+		... MonitorV2ServiceBindingValue
 	}
 }
 fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
@@ -23144,6 +23283,9 @@ fragment MonitorV2ColumnPath on MonitorV2ColumnPath {
 	name
 	path
 }
+fragment MonitorV2CorrelationTag on MonitorV2CorrelationTag {
+	tag
+}
 fragment MonitorV2IntervalSchedule on MonitorV2IntervalSchedule {
 	interval
 	randomize
@@ -23155,6 +23297,10 @@ fragment MonitorV2CronSchedule on MonitorV2CronSchedule {
 	rawCron
 	timezone
 	alarmMode
+}
+fragment MonitorV2ServiceBindingValue on MonitorV2ServiceBindingValue {
+	value
+	matchMode
 }
 fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {
 	comparison {
@@ -23982,6 +24128,9 @@ fragment MonitorV2Definition on MonitorV2Definition {
 		... MonitorV2Scheduling
 	}
 	customVariables
+	serviceBindings {
+		... MonitorV2ServiceBinding
+	}
 }
 fragment MonitorV2ActionRule on MonitorV2ActionRule {
 	actionID
@@ -24044,6 +24193,9 @@ fragment MonitorV2Column on MonitorV2Column {
 	columnPath {
 		... MonitorV2ColumnPath
 	}
+	correlationTag {
+		... MonitorV2CorrelationTag
+	}
 }
 fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	interval {
@@ -24054,6 +24206,17 @@ fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	}
 	scheduled {
 		... MonitorV2CronSchedule
+	}
+}
+fragment MonitorV2ServiceBinding on MonitorV2ServiceBinding {
+	serviceName {
+		... MonitorV2ServiceBindingValue
+	}
+	environment {
+		... MonitorV2ServiceBindingValue
+	}
+	serviceNamespace {
+		... MonitorV2ServiceBindingValue
 	}
 }
 fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
@@ -24118,6 +24281,9 @@ fragment MonitorV2ColumnPath on MonitorV2ColumnPath {
 	name
 	path
 }
+fragment MonitorV2CorrelationTag on MonitorV2CorrelationTag {
+	tag
+}
 fragment MonitorV2IntervalSchedule on MonitorV2IntervalSchedule {
 	interval
 	randomize
@@ -24129,6 +24295,10 @@ fragment MonitorV2CronSchedule on MonitorV2CronSchedule {
 	rawCron
 	timezone
 	alarmMode
+}
+fragment MonitorV2ServiceBindingValue on MonitorV2ServiceBindingValue {
+	value
+	matchMode
 }
 fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {
 	comparison {
@@ -24269,6 +24439,9 @@ fragment MonitorV2Definition on MonitorV2Definition {
 		... MonitorV2Scheduling
 	}
 	customVariables
+	serviceBindings {
+		... MonitorV2ServiceBinding
+	}
 }
 fragment MonitorV2ActionRule on MonitorV2ActionRule {
 	actionID
@@ -24331,6 +24504,9 @@ fragment MonitorV2Column on MonitorV2Column {
 	columnPath {
 		... MonitorV2ColumnPath
 	}
+	correlationTag {
+		... MonitorV2CorrelationTag
+	}
 }
 fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	interval {
@@ -24341,6 +24517,17 @@ fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	}
 	scheduled {
 		... MonitorV2CronSchedule
+	}
+}
+fragment MonitorV2ServiceBinding on MonitorV2ServiceBinding {
+	serviceName {
+		... MonitorV2ServiceBindingValue
+	}
+	environment {
+		... MonitorV2ServiceBindingValue
+	}
+	serviceNamespace {
+		... MonitorV2ServiceBindingValue
 	}
 }
 fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
@@ -24405,6 +24592,9 @@ fragment MonitorV2ColumnPath on MonitorV2ColumnPath {
 	name
 	path
 }
+fragment MonitorV2CorrelationTag on MonitorV2CorrelationTag {
+	tag
+}
 fragment MonitorV2IntervalSchedule on MonitorV2IntervalSchedule {
 	interval
 	randomize
@@ -24416,6 +24606,10 @@ fragment MonitorV2CronSchedule on MonitorV2CronSchedule {
 	rawCron
 	timezone
 	alarmMode
+}
+fragment MonitorV2ServiceBindingValue on MonitorV2ServiceBindingValue {
+	value
+	matchMode
 }
 fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {
 	comparison {
@@ -26199,6 +26393,9 @@ fragment MonitorV2Definition on MonitorV2Definition {
 		... MonitorV2Scheduling
 	}
 	customVariables
+	serviceBindings {
+		... MonitorV2ServiceBinding
+	}
 }
 fragment MonitorV2ActionRule on MonitorV2ActionRule {
 	actionID
@@ -26261,6 +26458,9 @@ fragment MonitorV2Column on MonitorV2Column {
 	columnPath {
 		... MonitorV2ColumnPath
 	}
+	correlationTag {
+		... MonitorV2CorrelationTag
+	}
 }
 fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	interval {
@@ -26271,6 +26471,17 @@ fragment MonitorV2Scheduling on MonitorV2Scheduling {
 	}
 	scheduled {
 		... MonitorV2CronSchedule
+	}
+}
+fragment MonitorV2ServiceBinding on MonitorV2ServiceBinding {
+	serviceName {
+		... MonitorV2ServiceBindingValue
+	}
+	environment {
+		... MonitorV2ServiceBindingValue
+	}
+	serviceNamespace {
+		... MonitorV2ServiceBindingValue
 	}
 }
 fragment MonitorV2ComparisonExpression on MonitorV2ComparisonExpression {
@@ -26335,6 +26546,9 @@ fragment MonitorV2ColumnPath on MonitorV2ColumnPath {
 	name
 	path
 }
+fragment MonitorV2CorrelationTag on MonitorV2CorrelationTag {
+	tag
+}
 fragment MonitorV2IntervalSchedule on MonitorV2IntervalSchedule {
 	interval
 	randomize
@@ -26346,6 +26560,10 @@ fragment MonitorV2CronSchedule on MonitorV2CronSchedule {
 	rawCron
 	timezone
 	alarmMode
+}
+fragment MonitorV2ServiceBindingValue on MonitorV2ServiceBindingValue {
+	value
+	matchMode
 }
 fragment MonitorV2ComparisonTerm on MonitorV2ComparisonTerm {
 	comparison {

--- a/client/meta/helpers.go
+++ b/client/meta/helpers.go
@@ -154,6 +154,11 @@ var AllMonitorV2AlarmModes = []MonitorV2AlarmMode{
 	MonitorV2AlarmModeOngoing,
 }
 
+var AllMonitorV2ServiceBindingMatchModes = []MonitorV2ServiceBindingMatchMode{
+	MonitorV2ServiceBindingMatchModeExact,
+	MonitorV2ServiceBindingMatchModeWildcard,
+}
+
 var AllMonitorV2ValueAggregations = []MonitorV2ValueAggregation{
 	MonitorV2ValueAggregationAllof,
 	MonitorV2ValueAggregationAnyof,

--- a/docs/data-sources/monitor_v2.md
+++ b/docs/data-sources/monitor_v2.md
@@ -66,6 +66,7 @@ stage pipelines.
 - `rule_kind` (String) Describes the type of each of the rules in the definition (they must all be the same type).
 - `rule_template` (Block List) Additional attributes for a monitor rule kind. Used for anomaly monitors to define the detection algorithm, out of bound condition, and more. (see [below for nested schema](#nestedblock--rule_template))
 - `rules` (Block List) All rules for this monitor must be of the same MonitorRuleKind as specified in ruleKind. Rules should be constructed logically such that a state transition null->Warning implies transition from null->Informational. (see [below for nested schema](#nestedblock--rules))
+- `service_bindings` (Block List) Declares the (service_name, environment, service_namespace) triplet this monitor's alarms are attributed to, aligned with OpenTelemetry semantic conventions. At most one binding is supported today. (see [below for nested schema](#nestedblock--service_bindings))
 - `stage` (Block List) A stage processes an input according to the provided pipeline. If no
 input is provided, a stage will implicitly follow on from the result of
 its predecessor. (see [below for nested schema](#nestedblock--stage))
@@ -194,6 +195,7 @@ Read-Only:
 Read-Only:
 
 - `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column--column_path))
+- `correlation_tag` (Block List) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column--correlation_tag))
 - `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column--link_column))
 
 <a id="nestedblock--actions--conditions--compare_terms--column--column_path"></a>
@@ -203,6 +205,14 @@ Read-Only:
 
 - `name` (String) The name of the column.
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--actions--conditions--compare_terms--column--correlation_tag"></a>
+### Nested Schema for `actions.conditions.compare_terms.column.correlation_tag`
+
+Read-Only:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--actions--conditions--compare_terms--column--link_column"></a>
@@ -237,6 +247,7 @@ Read-Only:
 Read-Only:
 
 - `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--groupings--column_path))
+- `correlation_tag` (Block List) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--groupings--correlation_tag))
 - `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--groupings--link_column))
 
 <a id="nestedblock--groupings--column_path"></a>
@@ -246,6 +257,14 @@ Read-Only:
 
 - `name` (String) The name of the column.
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--groupings--correlation_tag"></a>
+### Nested Schema for `groupings.correlation_tag`
+
+Read-Only:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--groupings--link_column"></a>
@@ -288,6 +307,7 @@ Read-Only:
 Read-Only:
 
 - `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--no_data_rules--anomaly--compare_groups--column--column_path))
+- `correlation_tag` (Block List) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--no_data_rules--anomaly--compare_groups--column--correlation_tag))
 - `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--no_data_rules--anomaly--compare_groups--column--link_column))
 
 <a id="nestedblock--no_data_rules--anomaly--compare_groups--column--column_path"></a>
@@ -297,6 +317,14 @@ Read-Only:
 
 - `name` (String) The name of the column.
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--no_data_rules--anomaly--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `no_data_rules.anomaly.compare_groups.column.correlation_tag`
+
+Read-Only:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--no_data_rules--anomaly--compare_groups--column--link_column"></a>
@@ -348,6 +376,7 @@ Read-Only:
 Read-Only:
 
 - `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--no_data_rules--threshold--compare_groups--column--column_path))
+- `correlation_tag` (Block List) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--no_data_rules--threshold--compare_groups--column--correlation_tag))
 - `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--no_data_rules--threshold--compare_groups--column--link_column))
 
 <a id="nestedblock--no_data_rules--threshold--compare_groups--column--column_path"></a>
@@ -357,6 +386,14 @@ Read-Only:
 
 - `name` (String) The name of the column.
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--no_data_rules--threshold--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `no_data_rules.threshold.compare_groups.column.correlation_tag`
+
+Read-Only:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--no_data_rules--threshold--compare_groups--column--link_column"></a>
@@ -460,6 +497,7 @@ Read-Only:
 Read-Only:
 
 - `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--rules--anomaly--compare_groups--column--column_path))
+- `correlation_tag` (Block List) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--rules--anomaly--compare_groups--column--correlation_tag))
 - `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--rules--anomaly--compare_groups--column--link_column))
 
 <a id="nestedblock--rules--anomaly--compare_groups--column--column_path"></a>
@@ -469,6 +507,14 @@ Read-Only:
 
 - `name` (String) The name of the column.
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--rules--anomaly--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `rules.anomaly.compare_groups.column.correlation_tag`
+
+Read-Only:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--rules--anomaly--compare_groups--column--link_column"></a>
@@ -518,6 +564,7 @@ Read-Only:
 Read-Only:
 
 - `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--rules--count--compare_groups--column--column_path))
+- `correlation_tag` (Block List) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--rules--count--compare_groups--column--correlation_tag))
 - `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--rules--count--compare_groups--column--link_column))
 
 <a id="nestedblock--rules--count--compare_groups--column--column_path"></a>
@@ -527,6 +574,14 @@ Read-Only:
 
 - `name` (String) The name of the column.
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--rules--count--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `rules.count.compare_groups.column.correlation_tag`
+
+Read-Only:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--rules--count--compare_groups--column--link_column"></a>
@@ -589,6 +644,7 @@ Read-Only:
 Read-Only:
 
 - `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--rules--promote--compare_columns--column--column_path))
+- `correlation_tag` (Block List) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--rules--promote--compare_columns--column--correlation_tag))
 - `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--rules--promote--compare_columns--column--link_column))
 
 <a id="nestedblock--rules--promote--compare_columns--column--column_path"></a>
@@ -598,6 +654,14 @@ Read-Only:
 
 - `name` (String) The name of the column.
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--rules--promote--compare_columns--column--correlation_tag"></a>
+### Nested Schema for `rules.promote.compare_columns.column.correlation_tag`
+
+Read-Only:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--rules--promote--compare_columns--column--link_column"></a>
@@ -649,6 +713,7 @@ Read-Only:
 Read-Only:
 
 - `column_path` (Block List) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--rules--threshold--compare_groups--column--column_path))
+- `correlation_tag` (Block List) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--rules--threshold--compare_groups--column--correlation_tag))
 - `link_column` (Block List) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--rules--threshold--compare_groups--column--link_column))
 
 <a id="nestedblock--rules--threshold--compare_groups--column--column_path"></a>
@@ -658,6 +723,14 @@ Read-Only:
 
 - `name` (String) The name of the column.
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--rules--threshold--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `rules.threshold.compare_groups.column.correlation_tag`
+
+Read-Only:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--rules--threshold--compare_groups--column--link_column"></a>
@@ -697,6 +770,43 @@ Read-Only:
 - `value_string` (List of String) list of size <=1 consisting of a string value.
 - `value_timestamp` (List of String) list of size <=1 consisting of a timestamp value.
 
+
+
+
+<a id="nestedblock--service_bindings"></a>
+### Nested Schema for `service_bindings`
+
+Read-Only:
+
+- `environment` (Block List) Environment dimension of the binding (OTel `deployment.environment.name`). (see [below for nested schema](#nestedblock--service_bindings--environment))
+- `service_name` (Block List) Service-name dimension of the binding (OTel `service.name`). (see [below for nested schema](#nestedblock--service_bindings--service_name))
+- `service_namespace` (Block List) Namespace dimension of the binding (OTel `service.namespace`). (see [below for nested schema](#nestedblock--service_bindings--service_namespace))
+
+<a id="nestedblock--service_bindings--environment"></a>
+### Nested Schema for `service_bindings.environment`
+
+Read-Only:
+
+- `match_mode` (String) How the dimension is matched: `exact` (default) matches the given `value`; `wildcard` matches any value.
+- `value` (String) Literal value to match for this dimension.
+
+
+<a id="nestedblock--service_bindings--service_name"></a>
+### Nested Schema for `service_bindings.service_name`
+
+Read-Only:
+
+- `match_mode` (String) How the dimension is matched: `exact` (default) matches the given `value`; `wildcard` matches any value.
+- `value` (String) Literal value to match for this dimension.
+
+
+<a id="nestedblock--service_bindings--service_namespace"></a>
+### Nested Schema for `service_bindings.service_namespace`
+
+Read-Only:
+
+- `match_mode` (String) How the dimension is matched: `exact` (default) matches the given `value`; `wildcard` matches any value.
+- `value` (String) Literal value to match for this dimension.
 
 
 

--- a/docs/resources/monitor_v2.md
+++ b/docs/resources/monitor_v2.md
@@ -148,6 +148,7 @@ its predecessor. (see [below for nested schema](#nestedblock--stage))
 - `no_data_rules` (Block List, Max: 1) No data rules allows a user to be alerted on missing data for the specified lookback window. When provided, the severity is fixed to the NoData severity. As of today, the max number of no data rules that can be created is 1 for the threshold monitor kind. (see [below for nested schema](#nestedblock--no_data_rules))
 - `rule_template` (Block List, Max: 1) Additional attributes for a monitor rule kind. Used for anomaly monitors to define the detection algorithm, out of bound condition, and more. (see [below for nested schema](#nestedblock--rule_template))
 - `scheduling` (Block List, Max: 1) Holds information about when the monitor should evaluate. The types of scheduling (transform, scheduled, and interval@deprecated) are exclusive. If omitted, defaults to transform. (see [below for nested schema](#nestedblock--scheduling))
+- `service_bindings` (Block List, Max: 1) Declares the (service_name, environment, service_namespace) triplet this monitor's alarms are attributed to, aligned with OpenTelemetry semantic conventions. At most one binding is supported today. (see [below for nested schema](#nestedblock--service_bindings))
 - `workspace` (String, Deprecated) OID of the workspace this object is contained in.
 
 ### Read-Only
@@ -192,6 +193,7 @@ Required:
 Optional:
 
 - `column_path` (Block List, Max: 1) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--rules--anomaly--compare_groups--column--column_path))
+- `correlation_tag` (Block List, Max: 1) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--rules--anomaly--compare_groups--column--correlation_tag))
 - `link_column` (Block List, Max: 1) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--rules--anomaly--compare_groups--column--link_column))
 
 <a id="nestedblock--rules--anomaly--compare_groups--column--column_path"></a>
@@ -204,6 +206,14 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--rules--anomaly--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `rules.anomaly.compare_groups.column.correlation_tag`
+
+Required:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--rules--anomaly--compare_groups--column--link_column"></a>
@@ -276,6 +286,7 @@ Required:
 Optional:
 
 - `column_path` (Block List, Max: 1) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--rules--count--compare_groups--column--column_path))
+- `correlation_tag` (Block List, Max: 1) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--rules--count--compare_groups--column--correlation_tag))
 - `link_column` (Block List, Max: 1) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--rules--count--compare_groups--column--link_column))
 
 <a id="nestedblock--rules--count--compare_groups--column--column_path"></a>
@@ -288,6 +299,14 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--rules--count--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `rules.count.compare_groups.column.correlation_tag`
+
+Required:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--rules--count--compare_groups--column--link_column"></a>
@@ -339,6 +358,7 @@ Required:
 Optional:
 
 - `column_path` (Block List, Max: 1) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--rules--promote--compare_columns--column--column_path))
+- `correlation_tag` (Block List, Max: 1) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--rules--promote--compare_columns--column--correlation_tag))
 - `link_column` (Block List, Max: 1) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--rules--promote--compare_columns--column--link_column))
 
 <a id="nestedblock--rules--promote--compare_columns--column--column_path"></a>
@@ -351,6 +371,14 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--rules--promote--compare_columns--column--correlation_tag"></a>
+### Nested Schema for `rules.promote.compare_columns.column.correlation_tag`
+
+Required:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--rules--promote--compare_columns--column--link_column"></a>
@@ -408,6 +436,7 @@ Required:
 Optional:
 
 - `column_path` (Block List, Max: 1) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--rules--threshold--compare_groups--column--column_path))
+- `correlation_tag` (Block List, Max: 1) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--rules--threshold--compare_groups--column--correlation_tag))
 - `link_column` (Block List, Max: 1) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--rules--threshold--compare_groups--column--link_column))
 
 <a id="nestedblock--rules--threshold--compare_groups--column--column_path"></a>
@@ -420,6 +449,14 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--rules--threshold--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `rules.threshold.compare_groups.column.correlation_tag`
+
+Required:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--rules--threshold--compare_groups--column--link_column"></a>
@@ -574,6 +611,7 @@ Required:
 Optional:
 
 - `column_path` (Block List, Max: 1) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column--column_path))
+- `correlation_tag` (Block List, Max: 1) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column--correlation_tag))
 - `link_column` (Block List, Max: 1) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--actions--conditions--compare_terms--column--link_column))
 
 <a id="nestedblock--actions--conditions--compare_terms--column--column_path"></a>
@@ -586,6 +624,14 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--actions--conditions--compare_terms--column--correlation_tag"></a>
+### Nested Schema for `actions.conditions.compare_terms.column.correlation_tag`
+
+Required:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--actions--conditions--compare_terms--column--link_column"></a>
@@ -623,6 +669,7 @@ Optional:
 Optional:
 
 - `column_path` (Block List, Max: 1) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--groupings--column_path))
+- `correlation_tag` (Block List, Max: 1) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--groupings--correlation_tag))
 - `link_column` (Block List, Max: 1) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--groupings--link_column))
 
 <a id="nestedblock--groupings--column_path"></a>
@@ -635,6 +682,14 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--groupings--correlation_tag"></a>
+### Nested Schema for `groupings.correlation_tag`
+
+Required:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--groupings--link_column"></a>
@@ -677,6 +732,7 @@ Required:
 Optional:
 
 - `column_path` (Block List, Max: 1) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--no_data_rules--anomaly--compare_groups--column--column_path))
+- `correlation_tag` (Block List, Max: 1) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--no_data_rules--anomaly--compare_groups--column--correlation_tag))
 - `link_column` (Block List, Max: 1) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--no_data_rules--anomaly--compare_groups--column--link_column))
 
 <a id="nestedblock--no_data_rules--anomaly--compare_groups--column--column_path"></a>
@@ -689,6 +745,14 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--no_data_rules--anomaly--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `no_data_rules.anomaly.compare_groups.column.correlation_tag`
+
+Required:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--no_data_rules--anomaly--compare_groups--column--link_column"></a>
@@ -746,6 +810,7 @@ Required:
 Optional:
 
 - `column_path` (Block List, Max: 1) Specifies how the user wants to group by a specific column name or a JSON object column that has a path. (see [below for nested schema](#nestedblock--no_data_rules--threshold--compare_groups--column--column_path))
+- `correlation_tag` (Block List, Max: 1) Marks this column as a correlation-tag grouping (e.g. `service.name`). (see [below for nested schema](#nestedblock--no_data_rules--threshold--compare_groups--column--correlation_tag))
 - `link_column` (Block List, Max: 1) Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources). (see [below for nested schema](#nestedblock--no_data_rules--threshold--compare_groups--column--link_column))
 
 <a id="nestedblock--no_data_rules--threshold--compare_groups--column--column_path"></a>
@@ -758,6 +823,14 @@ Required:
 Optional:
 
 - `path` (String) The path of the path, if the name refers to a column with a JSON object.
+
+
+<a id="nestedblock--no_data_rules--threshold--compare_groups--column--correlation_tag"></a>
+### Nested Schema for `no_data_rules.threshold.compare_groups.column.correlation_tag`
+
+Required:
+
+- `tag` (String) The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
 
 
 <a id="nestedblock--no_data_rules--threshold--compare_groups--column--link_column"></a>
@@ -876,6 +949,43 @@ Optional:
 Required:
 
 - `freshness_goal` (String) The freshness goal.
+
+
+
+<a id="nestedblock--service_bindings"></a>
+### Nested Schema for `service_bindings`
+
+Required:
+
+- `environment` (Block List, Min: 1, Max: 1) Environment dimension of the binding (OTel `deployment.environment.name`). (see [below for nested schema](#nestedblock--service_bindings--environment))
+- `service_name` (Block List, Min: 1, Max: 1) Service-name dimension of the binding (OTel `service.name`). (see [below for nested schema](#nestedblock--service_bindings--service_name))
+- `service_namespace` (Block List, Min: 1, Max: 1) Namespace dimension of the binding (OTel `service.namespace`). (see [below for nested schema](#nestedblock--service_bindings--service_namespace))
+
+<a id="nestedblock--service_bindings--environment"></a>
+### Nested Schema for `service_bindings.environment`
+
+Optional:
+
+- `match_mode` (String) How the dimension is matched: `exact` (default) matches the given `value`; `wildcard` matches any value.
+- `value` (String) Literal value to match for this dimension.
+
+
+<a id="nestedblock--service_bindings--service_name"></a>
+### Nested Schema for `service_bindings.service_name`
+
+Optional:
+
+- `match_mode` (String) How the dimension is matched: `exact` (default) matches the given `value`; `wildcard` matches any value.
+- `value` (String) Literal value to match for this dimension.
+
+
+<a id="nestedblock--service_bindings--service_namespace"></a>
+### Nested Schema for `service_bindings.service_namespace`
+
+Optional:
+
+- `match_mode` (String) How the dimension is matched: `exact` (default) matches the given `value`; `wildcard` matches any value.
+- `value` (String) Literal value to match for this dimension.
 ## Import
 Import is supported using the following syntax:
 ```shell

--- a/observe/data_source_monitor_v2.go
+++ b/observe/data_source_monitor_v2.go
@@ -356,6 +356,13 @@ func dataSourceMonitorV2() *schema.Resource {
 				Elem:        monitorV2ColumnDatasource(),
 				Description: descriptions.Get("monitorv2", "schema", "groupings"),
 			},
+			"service_bindings": { // [MonitorV2ServiceBindingInput!]
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Elem:        monitorV2ServiceBindingDimensionDatasource(),
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "description"),
+			},
 			"scheduling": { // MonitorV2SchedulingInput (required *only* for TF)
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -640,6 +647,70 @@ func monitorV2ColumnDatasource() *schema.Resource {
 				Computed:    true,
 				Elem:        monitorV2ColumnPathDatasource(),
 				Description: descriptions.Get("monitorv2", "schema", "column_path", "description"),
+			},
+			"correlation_tag": { // MonitorV2CorrelationTagInput
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Elem:        monitorV2CorrelationTagDatasource(),
+				Description: descriptions.Get("monitorv2", "schema", "correlation_tag", "description"),
+			},
+		},
+	}
+}
+
+func monitorV2CorrelationTagDatasource() *schema.Resource {
+	return &schema.Resource{ // MonitorV2CorrelationTagInput
+		Schema: map[string]*schema.Schema{
+			"tag": { // String!
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("monitorv2", "schema", "correlation_tag", "tag"),
+			},
+		},
+	}
+}
+
+func monitorV2ServiceBindingValueDatasource() *schema.Resource {
+	return &schema.Resource{ // MonitorV2ServiceBindingValueInput
+		Schema: map[string]*schema.Schema{
+			"value": { // String
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "value"),
+			},
+			"match_mode": { // MonitorV2ServiceBindingMatchMode
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "match_mode"),
+			},
+		},
+	}
+}
+
+func monitorV2ServiceBindingDimensionDatasource() *schema.Resource {
+	return &schema.Resource{ // MonitorV2ServiceBindingValueInput!
+		Schema: map[string]*schema.Schema{
+			"service_name": { // MonitorV2ServiceBindingValueInput!
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Elem:        monitorV2ServiceBindingValueDatasource(),
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "service_name"),
+			},
+			"environment": { // MonitorV2ServiceBindingValueInput!
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Elem:        monitorV2ServiceBindingValueDatasource(),
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "environment"),
+			},
+			"service_namespace": { // MonitorV2ServiceBindingValueInput!
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Elem:        monitorV2ServiceBindingValueDatasource(),
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "service_namespace"),
 			},
 		},
 	}

--- a/observe/descriptions/monitorv2.yaml
+++ b/observe/descriptions/monitorv2.yaml
@@ -122,6 +122,24 @@ schema:
       Identifies a link-type column created by connecting two different datasets' columns (primary sources & destination sources).
     name: |
       The name of the link column.
+  correlation_tag:
+    description: |
+      Marks this column as a correlation-tag grouping (e.g. `service.name`).
+    tag: |
+      The correlation tag name, e.g. "service.name". The leading '#' is implied and must not be included.
+  service_bindings:
+    description: |
+      Declares the (service_name, environment, service_namespace) triplet this monitor's alarms are attributed to, aligned with OpenTelemetry semantic conventions. At most one binding is supported today.
+    service_name: |
+      Service-name dimension of the binding (OTel `service.name`).
+    environment: |
+      Environment dimension of the binding (OTel `deployment.environment.name`).
+    service_namespace: |
+      Namespace dimension of the binding (OTel `service.namespace`).
+    value: |
+      Literal value to match for this dimension.
+    match_mode: |
+      How the dimension is matched: `exact` (default) matches the given `value`; `wildcard` matches any value.
   comparison:
     compare_fn: |
       the type of comparison (greater, less, equal, etc.)

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -369,6 +369,13 @@ func resourceMonitorV2() *schema.Resource {
 				Elem:        monitorV2ColumnResource(),
 				Description: descriptions.Get("monitorv2", "schema", "groupings"),
 			},
+			"service_bindings": { // [MonitorV2ServiceBindingInput!]
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1, // backend supports at most one today; list kept for forward-compat
+				Elem:        monitorV2ServiceBindingDimensionResource(),
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "description"),
+			},
 			"scheduling": { // MonitorV2SchedulingInput (required *only* for TF)
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -698,6 +705,76 @@ func monitorV2ColumnResource() *schema.Resource {
 				Elem:        monitorV2ColumnPathResource(),
 				Description: descriptions.Get("monitorv2", "schema", "column_path", "description"),
 			},
+			"correlation_tag": { // MonitorV2CorrelationTagInput
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem:        monitorV2CorrelationTagResource(),
+				Description: descriptions.Get("monitorv2", "schema", "correlation_tag", "description"),
+			},
+		},
+	}
+}
+
+func monitorV2CorrelationTagResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"tag": { // String!
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: descriptions.Get("monitorv2", "schema", "correlation_tag", "tag"),
+			},
+		},
+	}
+}
+
+func monitorV2ServiceBindingValueResource() *schema.Resource {
+	return &schema.Resource{ // MonitorV2ServiceBindingValueInput
+		Schema: map[string]*schema.Schema{
+			"value": { // String
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "value"),
+			},
+			"match_mode": { // MonitorV2ServiceBindingMatchMode
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          toSnake(string(gql.MonitorV2ServiceBindingMatchModeExact)),
+				ValidateDiagFunc: validateEnums(gql.AllMonitorV2ServiceBindingMatchModes),
+				DiffSuppressFunc: diffSuppressEnums,
+				Description:      descriptions.Get("monitorv2", "schema", "service_bindings", "match_mode"),
+			},
+		},
+	}
+}
+
+func monitorV2ServiceBindingDimensionResource() *schema.Resource {
+	return &schema.Resource{ // MonitorV2ServiceBindingValueInput!
+		Schema: map[string]*schema.Schema{
+			"service_name": { // MonitorV2ServiceBindingValueInput!
+				Type:        schema.TypeList,
+				Required:    true,
+				MinItems:    1,
+				MaxItems:    1,
+				Elem:        monitorV2ServiceBindingValueResource(),
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "service_name"),
+			},
+			"environment": { // MonitorV2ServiceBindingValueInput!
+				Type:        schema.TypeList,
+				Required:    true,
+				MinItems:    1,
+				MaxItems:    1,
+				Elem:        monitorV2ServiceBindingValueResource(),
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "environment"),
+			},
+			"service_namespace": { // MonitorV2ServiceBindingValueInput!
+				Type:        schema.TypeList,
+				Required:    true,
+				MinItems:    1,
+				MaxItems:    1,
+				Elem:        monitorV2ServiceBindingValueResource(),
+				Description: descriptions.Get("monitorv2", "schema", "service_bindings", "service_namespace"),
+			},
 		},
 	}
 }
@@ -882,6 +959,12 @@ func monitorV2ToResourceData(ctx context.Context, monitor *gql.MonitorV2, data *
 
 	if monitor.Definition.Groupings != nil {
 		if err := data.Set("groupings", monitorV2FlattenGroupings(monitor.Definition.Groupings)); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	}
+
+	if monitor.Definition.ServiceBindings != nil {
+		if err := data.Set("service_bindings", monitorV2FlattenServiceBindings(monitor.Definition.ServiceBindings)); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
@@ -1128,7 +1211,14 @@ func monitorV2FlattenColumn(gqlColumn gql.MonitorV2Column) []interface{} {
 	if gqlColumn.ColumnPath != nil {
 		column["column_path"] = monitorV2FlattenColumnPath(*gqlColumn.ColumnPath)
 	}
+	if gqlColumn.CorrelationTag != nil {
+		column["correlation_tag"] = monitorV2FlattenCorrelationTag(*gqlColumn.CorrelationTag)
+	}
 	return []interface{}{column}
+}
+
+func monitorV2FlattenCorrelationTag(gqlCorrelationTag gql.MonitorV2CorrelationTag) []interface{} {
+	return []interface{}{map[string]interface{}{"tag": gqlCorrelationTag.Tag}}
 }
 
 func monitorV2FlattenComparisons(gqlComparisons []gql.MonitorV2Comparison) []interface{} {
@@ -1188,9 +1278,38 @@ func monitorV2FlattenGroupings(gqlGroupings []gql.MonitorV2Column) []interface{}
 		if gqlGrouping.ColumnPath != nil {
 			grouping["column_path"] = monitorV2FlattenColumnPath(*gqlGrouping.ColumnPath)
 		}
+		if gqlGrouping.CorrelationTag != nil {
+			grouping["correlation_tag"] = monitorV2FlattenCorrelationTag(*gqlGrouping.CorrelationTag)
+		}
 		groupings = append(groupings, grouping)
 	}
 	return groupings
+}
+
+func monitorV2FlattenServiceBindings(gqlBindings []gql.MonitorV2ServiceBinding) []interface{} {
+	var bindings []interface{}
+	for _, b := range gqlBindings {
+		bindings = append(bindings, map[string]interface{}{
+			"service_name":      monitorV2FlattenServiceBindingValue(b.ServiceName),
+			"environment":       monitorV2FlattenServiceBindingValue(b.Environment),
+			"service_namespace": monitorV2FlattenServiceBindingValue(b.ServiceNamespace),
+		})
+	}
+	return bindings
+}
+
+func monitorV2FlattenServiceBindingValue(gqlValue gql.MonitorV2ServiceBindingValue) []interface{} {
+	value := map[string]interface{}{}
+	if gqlValue.Value != nil {
+		value["value"] = *gqlValue.Value
+	}
+	// MatchMode is nullable on read; default to "exact" to match the schema Default.
+	if gqlValue.MatchMode != nil {
+		value["match_mode"] = toSnake(string(*gqlValue.MatchMode))
+	} else {
+		value["match_mode"] = toSnake(string(gql.MonitorV2ServiceBindingMatchModeExact))
+	}
+	return []interface{}{value}
 }
 
 func monitorV2FlattenColumnPath(gqlColumnPath gql.MonitorV2ColumnPath) []interface{} {
@@ -1369,6 +1488,18 @@ func newMonitorV2DefinitionInput(data *schema.ResourceData) (defnInput *gql.Moni
 			groupings = append(groupings, *colInput)
 		}
 		defnInput.Groupings = groupings
+	}
+
+	if _, ok := data.GetOk("service_bindings"); ok {
+		serviceBindings := make([]gql.MonitorV2ServiceBindingInput, 0)
+		for i := range data.Get("service_bindings").([]interface{}) {
+			binding, diags := newMonitorV2ServiceBindingInput(fmt.Sprintf("service_bindings.%d.", i), data)
+			if diags.HasError() {
+				return nil, diags
+			}
+			serviceBindings = append(serviceBindings, *binding)
+		}
+		defnInput.ServiceBindings = serviceBindings
 	}
 	if lookbackTimeStr, ok := data.GetOk("lookback_time"); ok {
 		lookbackTime, err := types.ParseDurationScalar(lookbackTimeStr.(string))
@@ -1759,7 +1890,77 @@ func newMonitorV2ColumnInput(path string, data *schema.ResourceData) (column *gq
 		column.ColumnPath = columnPath
 	}
 
+	if _, ok := data.GetOk(fmt.Sprintf("%scorrelation_tag", path)); ok {
+		correlationTag, diags := newMonitorV2CorrelationTagInput(fmt.Sprintf("%scorrelation_tag.0.", path), data)
+		if diags.HasError() {
+			return nil, diags
+		}
+		column.CorrelationTag = correlationTag
+	}
+
 	return column, diags
+}
+
+func newMonitorV2CorrelationTagInput(path string, data *schema.ResourceData) (tag *gql.MonitorV2CorrelationTagInput, diags diag.Diagnostics) {
+	// required
+	name := data.Get(fmt.Sprintf("%stag", path)).(string)
+
+	// instantiation
+	tag = &gql.MonitorV2CorrelationTagInput{Tag: name}
+
+	return tag, diags
+}
+
+func newMonitorV2ServiceBindingInput(path string, data *schema.ResourceData) (binding *gql.MonitorV2ServiceBindingInput, diags diag.Diagnostics) {
+	// all three dimensions are required
+	serviceName, diags := newMonitorV2ServiceBindingValueInput(fmt.Sprintf("%sservice_name.0.", path), data)
+	if diags.HasError() {
+		return nil, diags
+	}
+	environment, diags := newMonitorV2ServiceBindingValueInput(fmt.Sprintf("%senvironment.0.", path), data)
+	if diags.HasError() {
+		return nil, diags
+	}
+	serviceNamespace, diags := newMonitorV2ServiceBindingValueInput(fmt.Sprintf("%sservice_namespace.0.", path), data)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	binding = &gql.MonitorV2ServiceBindingInput{
+		ServiceName:      *serviceName,
+		Environment:      *environment,
+		ServiceNamespace: *serviceNamespace,
+	}
+
+	return binding, diags
+}
+
+func newMonitorV2ServiceBindingValueInput(path string, data *schema.ResourceData) (value *gql.MonitorV2ServiceBindingValueInput, diags diag.Diagnostics) {
+	value = &gql.MonitorV2ServiceBindingValueInput{}
+
+	// match_mode has a "exact" default, so data.Get always returns a non-empty string.
+	matchMode := gql.MonitorV2ServiceBindingMatchMode(toCamel(data.Get(fmt.Sprintf("%smatch_mode", path)).(string)))
+	value.MatchMode = &matchMode
+
+	// value is optional; an empty string is treated as absent.
+	if v, ok := data.GetOk(fmt.Sprintf("%svalue", path)); ok {
+		s := v.(string)
+		value.Value = &s
+	}
+
+	// Mirror the backend's value/match_mode pairing rule so users get a fast, local error.
+	switch matchMode {
+	case gql.MonitorV2ServiceBindingMatchModeExact:
+		if value.Value == nil {
+			return nil, diag.Errorf("service binding dimension with match_mode=exact requires a non-empty value (path %q)", path)
+		}
+	case gql.MonitorV2ServiceBindingMatchModeWildcard:
+		if value.Value != nil {
+			return nil, diag.Errorf("service binding dimension with match_mode=wildcard must not set value (path %q)", path)
+		}
+	}
+
+	return value, diags
 }
 
 func newMonitorV2LinkColumnInput(path string, data *schema.ResourceData) (column *gql.MonitorV2LinkColumnInput, diags diag.Diagnostics) {

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -2,6 +2,7 @@ package observe
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -937,6 +938,562 @@ func TestAccObserveMonitorV2AlarmModeInvalid(t *testing.T) {
 				Config:      monitorV2AlarmModeConfig(randomPrefix, `alarm_mode = "bogus"`),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("to be one of"),
+			},
+		},
+	})
+}
+
+// monitorV2ServiceBindingsConfig renders a transform-scheduled threshold monitor
+// that optionally carries a service_bindings block (pass "" to omit it).
+func monitorV2ServiceBindingsConfig(prefix, bindingBlock string) string {
+	return fmt.Sprintf(monitorV2ConfigPreamble+`
+		resource "observe_monitor_v2" "first" {
+			workspace = data.observe_workspace.default.oid
+			rule_kind = "threshold"
+			name = "%[1]s"
+			lookback_time = "10m"
+			inputs = {
+				"test" = observe_datastream.test.dataset
+			}
+			stage {
+				pipeline = "colmake temp_number:14, groupme:12"
+			}
+			rules {
+				level = "informational"
+				threshold {
+					compare_values {
+						compare_fn = "greater"
+						value_int64 = [0]
+					}
+					value_column_name = "temp_number"
+					aggregation = "all_of"
+				}
+			}
+			%[2]s
+			scheduling {
+				transform {
+					freshness_goal = "15m"
+				}
+			}
+		}
+
+		data "observe_monitor_v2" "lookup" {
+			id = observe_monitor_v2.first.id
+		}
+	`, prefix, bindingBlock)
+}
+
+// monitorV2ServiceBindingsWildcardConfig renders a monitor with an all-wildcard
+// service binding. A wildcard dimension resolves its value at detection time from a
+// correlation-tag grouping, so the input dataset must carry the canonical correlation
+// tags (service.name / deployment.environment.name / service.namespace) on real
+// columns and the monitor must group by those tags. This requires, on the tenant:
+// the FlagEnableServiceMonitoring feature flag AND the customer-scoped
+// Compiler.propagateCorrelationTags layered setting (so the tags propagate from the
+// input dataset into the monitor's compiled schema).
+func monitorV2ServiceBindingsWildcardConfig(prefix string, nsWildcard bool) string {
+	// When nsWildcard is false the service_namespace dimension is exact, so its
+	// backing correlation tag, grouping, and depends_on entry are all dropped.
+	nsTagResource := `
+
+		resource "observe_correlation_tag" "ns" {
+			dataset = observe_dataset.tagged.oid
+			column  = "ns_name"
+			name    = "service.namespace"
+		}`
+	nsDependsOn := `
+				observe_correlation_tag.ns,`
+	nsGrouping := `
+			groupings {
+				correlation_tag {
+					tag = "service.namespace"
+				}
+			}`
+	nsBinding := `
+				service_namespace {
+					match_mode = "wildcard"
+				}`
+	if !nsWildcard {
+		nsTagResource = ""
+		nsDependsOn = ""
+		nsGrouping = ""
+		nsBinding = `
+				service_namespace {
+					value = "payments"
+				}`
+	}
+
+	return fmt.Sprintf(monitorV2ConfigPreamble+`
+		resource "observe_dataset" "tagged" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-tagged"
+			inputs    = { "test" = observe_datastream.test.dataset }
+			stage {
+				pipeline = <<-EOF
+					filter false
+					colmake svc_name:string("svc"), env_name:string("env"), ns_name:string("ns")
+				EOF
+			}
+		}
+
+		resource "observe_correlation_tag" "svc" {
+			dataset = observe_dataset.tagged.oid
+			column  = "svc_name"
+			name    = "service.name"
+		}
+		resource "observe_correlation_tag" "env" {
+			dataset = observe_dataset.tagged.oid
+			column  = "env_name"
+			name    = "deployment.environment.name"
+		}%[2]s
+
+		resource "observe_monitor_v2" "first" {
+			workspace     = data.observe_workspace.default.oid
+			rule_kind     = "threshold"
+			name          = "%[1]s"
+			lookback_time = "10m"
+			inputs        = { "test" = observe_dataset.tagged.oid }
+			depends_on = [
+				observe_correlation_tag.svc,
+				observe_correlation_tag.env,%[3]s
+			]
+			stage {
+				pipeline = "colmake temp_number:14"
+			}
+			rules {
+				level = "informational"
+				threshold {
+					compare_values {
+						compare_fn  = "greater"
+						value_int64 = [0]
+					}
+					value_column_name = "temp_number"
+					aggregation       = "all_of"
+				}
+			}
+			groupings {
+				correlation_tag {
+					tag = "service.name"
+				}
+			}
+			groupings {
+				correlation_tag {
+					tag = "deployment.environment.name"
+				}
+			}%[4]s
+			service_bindings {
+				service_name {
+					match_mode = "wildcard"
+				}
+				environment {
+					match_mode = "wildcard"
+				}%[5]s
+			}
+			scheduling {
+				transform {
+					freshness_goal = "15m"
+				}
+			}
+		}
+
+		data "observe_monitor_v2" "lookup" {
+			id = observe_monitor_v2.first.id
+		}
+	`, prefix, nsTagResource, nsDependsOn, nsGrouping, nsBinding)
+}
+
+// TestMonitorV2ServiceBindingSchema locks in the schema shape: service_bindings is
+// an Optional block capped at one entry, each of the three dimensions is a Required
+// single-entry block, and match_mode defaults to "exact" with enum validation and
+// case-insensitive diff suppression while value stays Optional.
+func TestMonitorV2ServiceBindingSchema(t *testing.T) {
+	sb, ok := resourceMonitorV2().Schema["service_bindings"]
+	if !ok {
+		t.Fatal("service_bindings field missing from the monitor v2 schema")
+	}
+	if !sb.Optional {
+		t.Error("service_bindings should be Optional")
+	}
+	if sb.MaxItems != 1 {
+		t.Errorf("service_bindings should have MaxItems=1, got %d", sb.MaxItems)
+	}
+
+	dimensions := sb.Elem.(*schema.Resource).Schema
+	for _, name := range []string{"service_name", "environment", "service_namespace"} {
+		dim, ok := dimensions[name]
+		if !ok {
+			t.Fatalf("service_bindings.%s missing", name)
+		}
+		if !dim.Required {
+			t.Errorf("service_bindings.%s should be Required", name)
+		}
+		if dim.MinItems != 1 || dim.MaxItems != 1 {
+			t.Errorf("service_bindings.%s should have MinItems=1 MaxItems=1, got %d/%d", name, dim.MinItems, dim.MaxItems)
+		}
+
+		value := dim.Elem.(*schema.Resource).Schema
+		matchMode := value["match_mode"]
+		if matchMode == nil {
+			t.Errorf("service_bindings.%s.match_mode missing", name)
+			continue
+		}
+		if !matchMode.Optional {
+			t.Errorf("service_bindings.%s.match_mode should be Optional", name)
+		}
+		if matchMode.Default != "exact" {
+			t.Errorf("service_bindings.%s.match_mode should default to \"exact\", got %v", name, matchMode.Default)
+		}
+		if matchMode.ValidateDiagFunc == nil {
+			t.Errorf("service_bindings.%s.match_mode should have a ValidateDiagFunc", name)
+		}
+		if matchMode.DiffSuppressFunc == nil {
+			t.Errorf("service_bindings.%s.match_mode should have a DiffSuppressFunc", name)
+		}
+		if v := value["value"]; v == nil || !v.Optional {
+			t.Errorf("service_bindings.%s.value should be Optional", name)
+		}
+	}
+}
+
+// TestMonitorV2CorrelationTagSchema verifies the correlation_tag column variant is
+// an Optional single-entry block with a Required tag, sitting alongside link_column
+// and column_path.
+func TestMonitorV2CorrelationTagSchema(t *testing.T) {
+	column := monitorV2ColumnResource().Schema
+	ct, ok := column["correlation_tag"]
+	if !ok {
+		t.Fatal("correlation_tag field missing from the column schema")
+	}
+	if !ct.Optional {
+		t.Error("correlation_tag should be Optional")
+	}
+	if ct.MaxItems != 1 {
+		t.Errorf("correlation_tag should have MaxItems=1, got %d", ct.MaxItems)
+	}
+	if tag := ct.Elem.(*schema.Resource).Schema["tag"]; tag == nil || !tag.Required {
+		t.Error("correlation_tag.tag should be Required")
+	}
+}
+
+// TestNewMonitorV2ServiceBindingInput verifies the expander maps each dimension's
+// value/match_mode into the GraphQL input, including a mixed exact/wildcard binding.
+func TestNewMonitorV2ServiceBindingInput(t *testing.T) {
+	sp := func(s string) *string { return &s }
+	exact := gql.MonitorV2ServiceBindingMatchModeExact
+	wildcard := gql.MonitorV2ServiceBindingMatchModeWildcard
+
+	cases := []struct {
+		name    string
+		binding map[string]interface{}
+		want    gql.MonitorV2ServiceBindingInput
+	}{
+		{
+			name: "all exact",
+			binding: map[string]interface{}{
+				"service_name":      []interface{}{map[string]interface{}{"value": "checkout", "match_mode": "exact"}},
+				"environment":       []interface{}{map[string]interface{}{"value": "prod", "match_mode": "exact"}},
+				"service_namespace": []interface{}{map[string]interface{}{"value": "payments", "match_mode": "exact"}},
+			},
+			want: gql.MonitorV2ServiceBindingInput{
+				ServiceName:      gql.MonitorV2ServiceBindingValueInput{Value: sp("checkout"), MatchMode: &exact},
+				Environment:      gql.MonitorV2ServiceBindingValueInput{Value: sp("prod"), MatchMode: &exact},
+				ServiceNamespace: gql.MonitorV2ServiceBindingValueInput{Value: sp("payments"), MatchMode: &exact},
+			},
+		},
+		{
+			name: "mixed wildcard",
+			binding: map[string]interface{}{
+				"service_name":      []interface{}{map[string]interface{}{"match_mode": "wildcard"}},
+				"environment":       []interface{}{map[string]interface{}{"match_mode": "wildcard"}},
+				"service_namespace": []interface{}{map[string]interface{}{"value": "payments", "match_mode": "exact"}},
+			},
+			want: gql.MonitorV2ServiceBindingInput{
+				ServiceName:      gql.MonitorV2ServiceBindingValueInput{MatchMode: &wildcard},
+				Environment:      gql.MonitorV2ServiceBindingValueInput{MatchMode: &wildcard},
+				ServiceNamespace: gql.MonitorV2ServiceBindingValueInput{Value: sp("payments"), MatchMode: &exact},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := schema.TestResourceDataRaw(t, resourceMonitorV2().Schema, map[string]interface{}{
+				"service_bindings": []interface{}{tc.binding},
+			})
+			got, diags := newMonitorV2ServiceBindingInput("service_bindings.0.", data)
+			if diags.HasError() {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+			if !reflect.DeepEqual(*got, tc.want) {
+				t.Errorf("expected %+v, got %+v", tc.want, *got)
+			}
+		})
+	}
+}
+
+// TestNewMonitorV2ServiceBindingValueInput_Validation mirrors the backend's
+// value/match_mode pairing rule client-side: exact requires a value, wildcard
+// forbids one. Checked without a backend or feature flag.
+func TestNewMonitorV2ServiceBindingValueInput_Validation(t *testing.T) {
+	cases := []struct {
+		name    string
+		dim     map[string]interface{}
+		wantErr bool
+	}{
+		{"exact with value", map[string]interface{}{"match_mode": "exact", "value": "x"}, false},
+		{"exact without value", map[string]interface{}{"match_mode": "exact"}, true},
+		{"wildcard without value", map[string]interface{}{"match_mode": "wildcard"}, false},
+		{"wildcard with value", map[string]interface{}{"match_mode": "wildcard", "value": "x"}, true},
+		// match_mode omitted -> schema Default "exact" applies, so a value is required and accepted.
+		{"omitted defaults to exact", map[string]interface{}{"value": "x"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := schema.TestResourceDataRaw(t, resourceMonitorV2().Schema, map[string]interface{}{
+				"service_bindings": []interface{}{
+					map[string]interface{}{
+						"service_name": []interface{}{tc.dim},
+					},
+				},
+			})
+			_, diags := newMonitorV2ServiceBindingValueInput("service_bindings.0.service_name.0.", data)
+			if tc.wantErr && !diags.HasError() {
+				t.Errorf("expected a validation error, got none")
+			}
+			if !tc.wantErr && diags.HasError() {
+				t.Errorf("unexpected validation error: %v", diags)
+			}
+		})
+	}
+}
+
+// TestMonitorV2FlattenServiceBindings verifies the read path snake-cases match_mode
+// and omits value for wildcard dimensions.
+func TestMonitorV2FlattenServiceBindings(t *testing.T) {
+	sp := func(s string) *string { return &s }
+	exact := gql.MonitorV2ServiceBindingMatchModeExact
+	wildcard := gql.MonitorV2ServiceBindingMatchModeWildcard
+
+	got := monitorV2FlattenServiceBindings([]gql.MonitorV2ServiceBinding{
+		{
+			ServiceName:      gql.MonitorV2ServiceBindingValue{Value: sp("checkout"), MatchMode: &exact},
+			Environment:      gql.MonitorV2ServiceBindingValue{MatchMode: &wildcard},
+			ServiceNamespace: gql.MonitorV2ServiceBindingValue{Value: sp("payments"), MatchMode: &exact},
+		},
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(got))
+	}
+	binding := got[0].(map[string]interface{})
+
+	serviceName := binding["service_name"].([]interface{})[0].(map[string]interface{})
+	if serviceName["value"] != "checkout" || serviceName["match_mode"] != "exact" {
+		t.Errorf("service_name flattened wrong: %+v", serviceName)
+	}
+
+	environment := binding["environment"].([]interface{})[0].(map[string]interface{})
+	if _, ok := environment["value"]; ok {
+		t.Errorf("environment should have no value for wildcard, got %+v", environment)
+	}
+	if environment["match_mode"] != "wildcard" {
+		t.Errorf("environment match_mode should be wildcard, got %v", environment["match_mode"])
+	}
+}
+
+// TestMonitorV2CorrelationTag_ExpandFlatten round-trips the correlation_tag column
+// variant through the expander and flattener.
+func TestMonitorV2CorrelationTag_ExpandFlatten(t *testing.T) {
+	// Expand: a column whose only variant is a correlation_tag grouping.
+	data := schema.TestResourceDataRaw(t, resourceMonitorV2().Schema, map[string]interface{}{
+		"groupings": []interface{}{
+			map[string]interface{}{
+				"correlation_tag": []interface{}{map[string]interface{}{"tag": "service.name"}},
+			},
+		},
+	})
+	col, diags := newMonitorV2ColumnInput("groupings.0.", data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if col.CorrelationTag == nil || col.CorrelationTag.Tag != "service.name" {
+		t.Fatalf("expected correlation_tag input with tag=service.name, got %+v", col.CorrelationTag)
+	}
+	if col.LinkColumn != nil || col.ColumnPath != nil {
+		t.Errorf("expected only correlation_tag to be set, got link=%v path=%v", col.LinkColumn, col.ColumnPath)
+	}
+
+	// Flatten: the read struct back into terraform state shape.
+	got := monitorV2FlattenCorrelationTag(gql.MonitorV2CorrelationTag{Tag: "service.name"})
+	want := []interface{}{map[string]interface{}{"tag": "service.name"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %+v, got %+v", want, got)
+	}
+}
+
+// TestAccObserveMonitorV2ServiceBindingsExact exercises the exact-match service
+// binding lifecycle: create, read-back via the data source, no-drift re-plan, and
+// clearing the binding by removing the block.
+//
+// NOTE: requires the FlagEnableServiceMonitoring feature flag on the test tenant;
+// otherwise the backend rejects any service binding.
+func TestAccObserveMonitorV2ServiceBindingsExact(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+	bindings := `
+		service_bindings {
+			service_name {
+				value = "checkout"
+			}
+			environment {
+				value      = "prod"
+				match_mode = "exact"
+			}
+			service_namespace {
+				value = "payments"
+			}
+		}`
+	withBinding := monitorV2ServiceBindingsConfig(randomPrefix, bindings)
+	updatedBindings := `
+		service_bindings {
+			service_name {
+				value = "frontend"
+			}
+			environment {
+				value      = "staging"
+				match_mode = "exact"
+			}
+			service_namespace {
+				value = "checkout"
+			}
+		}`
+	withUpdatedBinding := monitorV2ServiceBindingsConfig(randomPrefix, updatedBindings)
+	noBinding := monitorV2ServiceBindingsConfig(randomPrefix, "")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: withBinding,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_name.0.value", "checkout"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_name.0.match_mode", "exact"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.environment.0.value", "prod"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_namespace.0.value", "payments"),
+					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "service_bindings.0.service_name.0.value", "checkout"),
+					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "service_bindings.0.service_namespace.0.value", "payments"),
+				),
+			},
+			// Re-applying the same config produces no diff.
+			testAccPlanOnlyNoDriftStep(withBinding),
+			{
+				// Update: changing the binding's values updates it in place.
+				Config: withUpdatedBinding,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_name.0.value", "frontend"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.environment.0.value", "staging"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_namespace.0.value", "checkout"),
+					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "service_bindings.0.service_name.0.value", "frontend"),
+					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "service_bindings.0.environment.0.value", "staging"),
+				),
+			},
+			testAccPlanOnlyNoDriftStep(withUpdatedBinding),
+			{
+				// Removing the block clears the binding (input fully replaces stored bindings).
+				Config: noBinding,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccObserveMonitorV2ServiceBindingsWildcard exercises an all-wildcard binding
+// backed by correlation_tag groupings over a dataset whose columns are correlation-
+// tagged with the canonical tags.
+//
+// NOTE: requires, on the tenant, the FlagEnableServiceMonitoring feature flag AND the
+// customer-scoped Compiler.propagateCorrelationTags layered setting enabled, so the
+// input dataset's correlation tags propagate into the monitor's compiled schema and
+// the wildcard dimensions validate at save time.
+func TestAccObserveMonitorV2ServiceBindingsWildcard(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+	allWildcard := monitorV2ServiceBindingsWildcardConfig(randomPrefix, true)
+	nsExact := monitorV2ServiceBindingsWildcardConfig(randomPrefix, false)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: allWildcard,
+				// ExpectNonEmptyPlan: applying the three correlation tags mutates the
+				// input dataset, bumping the version timestamp embedded in its OID. That
+				// re-resolved OID forces the ForceNew observe_correlation_tag resources to
+				// "replace" and churns the monitor's inputs map on the next plan. This is a
+				// correlation_tag/dataset OID-versioning artifact, NOT the service binding:
+				// the service_bindings and groupings blocks round-trip with no diff (verified
+				// in CI — only inputs churns). The Check below still asserts the wildcard
+				// binding created and reads back correctly.
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_name.0.match_mode", "wildcard"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_name.0.value", ""),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.environment.0.match_mode", "wildcard"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_namespace.0.match_mode", "wildcard"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "groupings.#", "3"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "groupings.0.correlation_tag.0.tag", "service.name"),
+					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "service_bindings.0.service_name.0.match_mode", "wildcard"),
+				),
+			},
+			{
+				// Update: flip service_namespace wildcard->exact, which lets us drop its
+				// correlation_tag grouping and backing tag. Exercises both a binding update
+				// and a change to the set of correlation-tag groupings (3 -> 2). Deleting the
+				// tag re-bumps the dataset OID, so the same churn applies (ExpectNonEmptyPlan).
+				Config:             nsExact,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_name.0.match_mode", "wildcard"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.environment.0.match_mode", "wildcard"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_namespace.0.match_mode", "exact"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_namespace.0.value", "payments"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "groupings.#", "2"),
+					resource.TestCheckResourceAttr("observe_monitor_v2.first", "groupings.1.correlation_tag.0.tag", "deployment.environment.name"),
+					resource.TestCheckResourceAttr("data.observe_monitor_v2.lookup", "service_bindings.0.service_namespace.0.value", "payments"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccObserveMonitorV2ServiceBindingsInvalid verifies the client-side
+// value/match_mode pairing rule fails the apply before any backend call (so no
+// feature flag is needed): a wildcard dimension may not carry a value.
+func TestAccObserveMonitorV2ServiceBindingsInvalid(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+	bindings := `
+		service_bindings {
+			service_name {
+				match_mode = "wildcard"
+				value      = "checkout"
+			}
+			environment {
+				value = "prod"
+			}
+			service_namespace {
+				value = "payments"
+			}
+		}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      monitorV2ServiceBindingsConfig(randomPrefix, bindings),
+				ExpectError: regexp.MustCompile("match_mode=wildcard must not set value"),
 			},
 		},
 	})


### PR DESCRIPTION
Adds a `service_bindings` block to the monitor_v2 resource and data source, letting a monitor declare the (service_name, environment, service_namespace) triplet its alarms are attributed to. Each dimension matches either an exact value or a wildcard; wildcard dimensions resolve their value at detection time from a backing column, so this also adds the `correlation_tag` column variant (alongside link_column/column_path) used to declare those backing groupings.

The GraphQL schema types and input-side generated structs already existed; this wires up the read fragments (regenerating the client), the Terraform schema, expand/flatten, client-side value/match_mode validation, descriptions, and docs.