### PR TITLE
feat(poller): add cloudwatch metrics poller attach_resource_tags var

### DIFF
--- a/client/internal/meta/operation/poller.graphql
+++ b/client/internal/meta/operation/poller.graphql
@@ -81,6 +81,7 @@ fragment Poller on Poller {
 			delay
 			region
 			assumeRoleArn
+			attachResourceTags
 			queries {
 				namespace
 				metricNames

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -9342,16 +9342,17 @@ func (v *PollerConfigPollerAWSSnapshotConfig) GetIncludeActions() []string { ret
 
 // PollerConfigPollerCloudWatchMetricsConfig includes the requested fields of the GraphQL type PollerCloudWatchMetricsConfig.
 type PollerConfigPollerCloudWatchMetricsConfig struct {
-	Typename      *string                                                                              `json:"__typename"`
-	Retries       *types.Int64Scalar                                                                   `json:"retries"`
-	Interval      *types.DurationScalar                                                                `json:"interval"`
-	Tags          *types.JsonObject                                                                    `json:"tags"`
-	Chunk         *PollerConfigChunkPollerChunkConfig                                                  `json:"chunk"`
-	Period        types.Int64Scalar                                                                    `json:"period"`
-	Delay         types.Int64Scalar                                                                    `json:"delay"`
-	Region        string                                                                               `json:"region"`
-	AssumeRoleArn string                                                                               `json:"assumeRoleArn"`
-	Queries       []PollerConfigPollerCloudWatchMetricsConfigQueriesPollerCloudWatchMetricsQueryConfig `json:"queries"`
+	Typename           *string                                                                              `json:"__typename"`
+	Retries            *types.Int64Scalar                                                                   `json:"retries"`
+	Interval           *types.DurationScalar                                                                `json:"interval"`
+	Tags               *types.JsonObject                                                                    `json:"tags"`
+	Chunk              *PollerConfigChunkPollerChunkConfig                                                  `json:"chunk"`
+	Period             types.Int64Scalar                                                                    `json:"period"`
+	Delay              types.Int64Scalar                                                                    `json:"delay"`
+	Region             string                                                                               `json:"region"`
+	AssumeRoleArn      string                                                                               `json:"assumeRoleArn"`
+	AttachResourceTags bool                                                                                 `json:"attachResourceTags"`
+	Queries            []PollerConfigPollerCloudWatchMetricsConfigQueriesPollerCloudWatchMetricsQueryConfig `json:"queries"`
 }
 
 // GetTypename returns PollerConfigPollerCloudWatchMetricsConfig.Typename, and is useful for accessing the field via an interface.
@@ -9384,6 +9385,11 @@ func (v *PollerConfigPollerCloudWatchMetricsConfig) GetRegion() string { return 
 
 // GetAssumeRoleArn returns PollerConfigPollerCloudWatchMetricsConfig.AssumeRoleArn, and is useful for accessing the field via an interface.
 func (v *PollerConfigPollerCloudWatchMetricsConfig) GetAssumeRoleArn() string { return v.AssumeRoleArn }
+
+// GetAttachResourceTags returns PollerConfigPollerCloudWatchMetricsConfig.AttachResourceTags, and is useful for accessing the field via an interface.
+func (v *PollerConfigPollerCloudWatchMetricsConfig) GetAttachResourceTags() bool {
+	return v.AttachResourceTags
+}
 
 // GetQueries returns PollerConfigPollerCloudWatchMetricsConfig.Queries, and is useful for accessing the field via an interface.
 func (v *PollerConfigPollerCloudWatchMetricsConfig) GetQueries() []PollerConfigPollerCloudWatchMetricsConfigQueriesPollerCloudWatchMetricsQueryConfig {
@@ -17835,6 +17841,7 @@ fragment Poller on Poller {
 			delay
 			region
 			assumeRoleArn
+			attachResourceTags
 			queries {
 				namespace
 				metricNames
@@ -21612,6 +21619,7 @@ fragment Poller on Poller {
 			delay
 			region
 			assumeRoleArn
+			attachResourceTags
 			queries {
 				namespace
 				metricNames
@@ -26586,6 +26594,7 @@ fragment Poller on Poller {
 			delay
 			region
 			assumeRoleArn
+			attachResourceTags
 			queries {
 				namespace
 				metricNames

--- a/docs/resources/poller.md
+++ b/docs/resources/poller.md
@@ -115,6 +115,7 @@ Required:
 
 Optional:
 
+- `attach_resource_tags` (Boolean) When enabled, the poller fetches and attaches AWS resource tags to collected metrics.
 - `delay` (String) Collection delay. Must account for metrics availability via CloudWatch API.
 - `period` (String) Metric resolution. Must be a multiple of 60s. When omitted, poller interval will be used.
 

--- a/observe/descriptions/poller.yaml
+++ b/observe/descriptions/poller.yaml
@@ -24,6 +24,8 @@ schema:
       AWS Region to scrape from.
     assume_role_arn: |
       AWS role to assume when scraping AWS CloudWatch Metrics. External ID will be set to datastream ID.
+    attach_resource_tags: |
+      When enabled, the poller fetches and attaches AWS resource tags to collected metrics.
     query:
       description: |
         Query specification.

--- a/observe/resource_poller.go
+++ b/observe/resource_poller.go
@@ -421,6 +421,12 @@ func resourcePoller() *schema.Resource {
 							Description: descriptions.Get("poller", "schema", "cloudwatch_metrics", "assume_role_arn"),
 							Required:    true,
 						},
+						"attach_resource_tags": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: descriptions.Get("poller", "schema", "cloudwatch_metrics", "attach_resource_tags"),
+						},
 						"query": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -652,6 +658,8 @@ func newPollerConfig(data *schema.ResourceData) (input *gql.PollerInput, diags d
 			AssumeRoleArn: data.Get("cloudwatch_metrics.0.assume_role_arn").(string),
 			Queries:       expandCloudWatchMetricsQueries(data, "cloudwatch_metrics.0.query"),
 		}
+		b := data.Get("cloudwatch_metrics.0.attach_resource_tags").(bool)
+		m.AttachResourceTags = &b
 
 		if v, ok := data.GetOk("cloudwatch_metrics.0.period"); ok {
 			str := v.(string)
@@ -954,10 +962,11 @@ func resourcePollerRead(ctx context.Context, data *schema.ResourceData, meta int
 			queries = append(queries, v)
 		}
 		cfg := map[string]any{
-			"delay":           time.Duration(int64(cloudWatchMetricsConfig.Delay) * int64(time.Second)).String(),
-			"region":          cloudWatchMetricsConfig.Region,
-			"assume_role_arn": cloudWatchMetricsConfig.AssumeRoleArn,
-			"query":           queries,
+			"delay":                time.Duration(int64(cloudWatchMetricsConfig.Delay) * int64(time.Second)).String(),
+			"region":               cloudWatchMetricsConfig.Region,
+			"assume_role_arn":      cloudWatchMetricsConfig.AssumeRoleArn,
+			"attach_resource_tags": cloudWatchMetricsConfig.AttachResourceTags,
+			"query":                queries,
 		}
 
 		period := time.Duration(int64(cloudWatchMetricsConfig.Period) * int64(time.Second))

--- a/observe/resource_poller_test.go
+++ b/observe/resource_poller_test.go
@@ -602,6 +602,33 @@ func TestAccObservePollerCloudWatchMetrics(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_poller.first", "cloudwatch_metrics.0.query.0.resource_filter.#", "0"),
 				),
 			},
+			{
+				Config: fmt.Sprintf(configPreamble+`
+				resource "observe_datastream" "example" {
+					workspace = data.observe_workspace.default.oid
+					name      = "%s-%s"
+					icon_url  = "test"
+				}
+				resource "observe_poller" "first" {
+					workspace  = data.observe_workspace.default.oid
+					name       = "%s"
+					interval   = "5m"
+					datastream = observe_datastream.example.oid
+
+					cloudwatch_metrics {
+						assume_role_arn      = "arn:aws:iam::123456789012:role/metric-role"
+						region               = "us-west-2"
+						attach_resource_tags = true
+
+						query {
+							namespace = "AWS/EC2"
+						}
+					}
+				}`, randomPrefix, "pollers", randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_poller.first", "cloudwatch_metrics.0.attach_resource_tags", "true"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
I verified this by using the provider locally and creating / updating a poller in my Observe eng account.