### PR TITLE
fix(build): restore ../observe as OBSERVE_ROOT default

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ VERSION?=$(shell git describe --tags --always)
 TESTARGS?=
 SWEEP?=^tf-\\d{16}
 SWEEP_DIR?=./observe
-OBSERVE_ROOT?=~/observe
+OBSERVE_ROOT?=../observe
 OBSERVE_DOCS_ROOT?=../observe-docs
 
 default: build


### PR DESCRIPTION
The ~/observe value was introduced incidentally in an unrelated sed-fix commit and never expands: Make does not expand ~ and quoted recipe usages suppress shell tilde expansion. Revert to the sibling ../observe convention