### PR TITLE
feat: warn on `terraform apply` for inefficient acceleration.

### DIFF
--- a/client/internal/meta/operation/dataset.graphql
+++ b/client/internal/meta/operation/dataset.graphql
@@ -7,6 +7,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	accelerationDisabledSource
+	accelerationType
 	version
 	lastSaved
 	pathCost

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -19,6 +19,25 @@ const (
 	AccelerationDisabledSourceView    AccelerationDisabledSource = "View"
 )
 
+type AccelerationType string
+
+const (
+	// Dataset can be accelerated by inserting new rows as they come in. This is
+	// the most efficient form of acceleration.
+	AccelerationTypeInsertonly AccelerationType = "InsertOnly"
+	// Dataset can be accelerated by aggregating new rows as they come in. This
+	// usually happens when we have a time-based aggregation, ex: timechart.
+	// Also efficient.
+	AccelerationTypeAggregation AccelerationType = "Aggregation"
+	// Dataset can be accelerated, but it's not insert-only or aggregation.
+	// Such acceleration usually requires reading more data than just
+	// the new rows, and rewrite existing data. It is usually less efficient
+	// than the other types.
+	AccelerationTypeOther AccelerationType = "Other"
+	// Dataset cannot be accelerated.
+	AccelerationTypeNotsupported AccelerationType = "NotSupported"
+)
+
 type ActionInput struct {
 	Name             *string               `json:"name"`
 	IconUrl          *string               `json:"iconUrl"`
@@ -1295,6 +1314,7 @@ type Dataset struct {
 	IconUrl                    *string                                              `json:"iconUrl"`
 	AccelerationDisabled       bool                                                 `json:"accelerationDisabled"`
 	AccelerationDisabledSource AccelerationDisabledSource                           `json:"accelerationDisabledSource"`
+	AccelerationType           AccelerationType                                     `json:"accelerationType"`
 	Version                    types.TimeScalar                                     `json:"version"`
 	LastSaved                  types.TimeScalar                                     `json:"lastSaved"`
 	PathCost                   *types.Int64Scalar                                   `json:"pathCost"`
@@ -1338,6 +1358,9 @@ func (v *Dataset) GetAccelerationDisabled() bool { return v.AccelerationDisabled
 func (v *Dataset) GetAccelerationDisabledSource() AccelerationDisabledSource {
 	return v.AccelerationDisabledSource
 }
+
+// GetAccelerationType returns Dataset.AccelerationType, and is useful for accessing the field via an interface.
+func (v *Dataset) GetAccelerationType() AccelerationType { return v.AccelerationType }
 
 // GetVersion returns Dataset.Version, and is useful for accessing the field via an interface.
 func (v *Dataset) GetVersion() types.TimeScalar { return v.Version }
@@ -17599,6 +17622,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	accelerationDisabledSource
+	accelerationType
 	version
 	lastSaved
 	pathCost
@@ -19697,6 +19721,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	accelerationDisabledSource
+	accelerationType
 	version
 	lastSaved
 	pathCost
@@ -20031,6 +20056,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	accelerationDisabledSource
+	accelerationType
 	version
 	lastSaved
 	pathCost
@@ -21063,6 +21089,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	accelerationDisabledSource
+	accelerationType
 	version
 	lastSaved
 	pathCost
@@ -22048,6 +22075,7 @@ fragment Dataset on Dataset {
 	iconUrl
 	accelerationDisabled
 	accelerationDisabledSource
+	accelerationType
 	version
 	lastSaved
 	pathCost

--- a/docs/data-sources/dataset.md
+++ b/docs/data-sources/dataset.md
@@ -40,6 +40,7 @@ one workspace, the server automatically assigns the correct workspace.
 
 - `acceleration_disabled` (Boolean)
 - `acceleration_disabled_source` (String)
+- `acceleration_type` (String) Acceleration type of the dataset, as determined by its pipeline. One of "insert_only", "aggregation", "other", or "not_supported".
 - `correlation_tag` (Block List) Correlation tags associated with this dataset. (see [below for nested schema](#nestedblock--correlation_tag))
 - `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI. Not intended to be configured by hand, please use export functionality.
 - `description` (String) Dataset description.

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -81,6 +81,7 @@ one workspace, the server automatically assigns the correct workspace.
 
 ### Read-Only
 
+- `acceleration_type` (String) Acceleration type of the dataset, as determined by its pipeline. One of "insert_only", "aggregation", "other", or "not_supported".
 - `id` (String) The ID of this resource.
 - `oid` (String) OID (Observe ID) for this object. This is the canonical identifier that
 should be used when referring to this object in terraform manifests.

--- a/observe/data_source_dataset.go
+++ b/observe/data_source_dataset.go
@@ -69,6 +69,11 @@ func dataSourceDataset() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"acceleration_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("dataset", "schema", "acceleration_type"),
+			},
 			"path_cost": {
 				Type:        schema.TypeInt,
 				Computed:    true,

--- a/observe/descriptions/dataset.yaml
+++ b/observe/descriptions/dataset.yaml
@@ -17,6 +17,8 @@ schema:
     Disables periodic materialization of the dataset
   acceleration_disabled_source: |
     Source of disabled materialization
+  acceleration_type: |
+    Acceleration type of the dataset, as determined by its pipeline. One of "insert_only", "aggregation", "other", or "not_supported".
   data_table_view_state: |
     JSON representation of state used for dataset formatting in the UI. Not intended to be configured by hand, please use export functionality.
   storage_integration: |

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -33,6 +33,12 @@ var AllRematerializationModes = []TerraformRematerializationMode{
 	RematerializationModeMustSkipRematerialization,
 }
 
+var diagInefficientAcceleration = diag.Diagnostic{
+	Severity: diag.Warning,
+	Summary:  "Dataset has inefficient acceleration type",
+	Detail:   "This dataset's pipeline results in acceleration type 'other', which may require reading and rewriting existing data. Consider restructuring the pipeline to achieve insert_only or aggregation acceleration.",
+}
+
 func resourceDataset() *schema.Resource {
 	return &schema.Resource{
 		Description:   descriptions.Get("dataset", "description"),
@@ -506,6 +512,10 @@ func resourceDatasetCreate(ctx context.Context, data *schema.ResourceData, meta 
 		return diags
 	}
 
+	if result.AccelerationType == gql.AccelerationTypeOther {
+		diags = append(diags, diagInefficientAcceleration)
+	}
+
 	data.SetId(result.Id)
 	return append(diags, resourceDatasetRead(ctx, data, meta)...)
 }
@@ -587,7 +597,11 @@ func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta 
 		return diags
 	}
 
-	return datasetToResourceData(result, data, false)
+	if result.AccelerationType == gql.AccelerationTypeOther {
+		diags = append(diags, diagInefficientAcceleration)
+	}
+
+	return append(diags, datasetToResourceData(result, data, false)...)
 }
 
 func resourceDatasetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -109,6 +109,11 @@ func resourceDataset() *schema.Resource {
 				DiffSuppressFunc: diffSuppressEnums,
 				Description:      descriptions.Get("dataset", "schema", "acceleration_disabled_source"),
 			},
+			"acceleration_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("dataset", "schema", "acceleration_type"),
+			},
 			"inputs": {
 				Type:             schema.TypeMap,
 				Required:         true,
@@ -359,6 +364,10 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData, mirrorDepr
 	}
 
 	if err := data.Set("acceleration_disabled_source", toSnake(string(d.AccelerationDisabledSource))); err != nil {
+		diags = append(diags, diag.FromErr(err)...)
+	}
+
+	if err := data.Set("acceleration_type", toSnake(string(d.AccelerationType))); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 


### PR DESCRIPTION
Adds acceleration_type as a computed read-only field to the observe_dataset resource and data source, and emits a Terraform warning on apply when a dataset's pipeline results in acceleration type other.

Dataset acceleration falls into four types:
- insert_only (most efficient)
- aggregation (efficient)
- other (likely expensive)
- not_supported

Unlike datasets created in the UI, datasets created in terraform do not receive this AccelerationType information, making it easy to accidentally create expensive datasets without feedback. This change adds a warning on `terraform apply` if acceleration falls under the 'other' type. The 'not_supported' type is already being caught as an error.

Changes
- Adds accelerationType to the Dataset GraphQL fragment and regenerates the client
- Exposes acceleration_type as a computed field on the resource and data source
- Emits a warning diagnostic on create and update when acceleration_type == "other"

Notes
- Warning fires after apply, not during plan. terraform-plugin-sdk/v2's CustomizeDiff only supports returning errors — there is no mechanism to surface a warning at plantime. Showing this before the "yes" prompt would require migrating to terraform-plugin-framework, which supports diag.Diagnostics in PlanModifiers.
- acceleration_type is (known after apply) during plan. Seems to be because acceleration_type is not returned in preflight mode, so surfacing acceleration_type during plan will require backend change.
- I opted not to use PipelineWarning.ExpensiveAcceleration (which is more definitive than acceleration_type==other which is only "likely expensive"). The checkQueries GraphQL operation compiles a pipeline without saving it and returns PipelineWarning results, including an ExpensiveAcceleration kind. However, checkQueries is not currently wired up in this provider and would require a new GraphQL operation and client method. 

Example terraform output:
[demo.txt](https://github.com/user-attachments/files/30484884/demo.txt)