### PR TITLE
feat: remove entity_tags from data source schemas

### DIFF
--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -22,7 +22,6 @@ Fetches data for an existing Observe dashboard.
 ### Read-Only
 
 - `description` (String) Dashboard description.
-- `entity_tags` (Map of String, Deprecated) Use object_tags instead.
 - `icon_url` (String) Icon image.
 - `layout` (String) Dashboard layout in JSON format.
 - `name` (String) Dashboard name. Must be unique within workspace.

--- a/docs/data-sources/dataset.md
+++ b/docs/data-sources/dataset.md
@@ -44,7 +44,6 @@ one workspace, the server automatically assigns the correct workspace.
 - `correlation_tag` (Block List) Correlation tags associated with this dataset. (see [below for nested schema](#nestedblock--correlation_tag))
 - `data_table_view_state` (String) JSON representation of state used for dataset formatting in the UI. Not intended to be configured by hand, please use export functionality.
 - `description` (String) Dataset description.
-- `entity_tags` (Map of String, Deprecated) Use object_tags instead.
 - `freshness` (String) Target freshness for results. Tighten the freshness to increase the
 frequency with which queries are run, which incurs higher transform costs.
 - `icon_url` (String) Icon to be displayed for this object. Icons are sourced from the [fluency-filled](https://icons8.com/icons/fluency-systems-filled) icon set.

--- a/docs/data-sources/worksheet.md
+++ b/docs/data-sources/worksheet.md
@@ -36,7 +36,6 @@ data "observe_worksheet" "lookup" {
 
 ### Read-Only
 
-- `entity_tags` (Map of String, Deprecated) Use object_tags instead.
 - `icon_url` (String) Icon image.
 - `name` (String) Worksheet name. Must be unique within workspace.
 - `object_tags` (Map of String) Object tags for organizing and categorizing workspace objects. Map keys are tag names, values are comma-separated lists. Values are parsed as CSV format for proper escaping. Leading/trailing spaces are automatically trimmed, internal spaces are preserved. Values containing commas must be quoted using CSV escaping.

--- a/observe/data_source_dashboard.go
+++ b/observe/data_source_dashboard.go
@@ -70,7 +70,6 @@ func dataSourceDashboard() *schema.Resource {
 				Description: schemaDashboardParameterValuesDescription,
 			},
 			"object_tags": objectTagsSchemaFieldComputed(),
-			"entity_tags": entityTagsSchemaFieldComputed(),
 		},
 	}
 }
@@ -87,7 +86,7 @@ func dataSourceDashboardRead(ctx context.Context, data *schema.ResourceData, met
 	}
 	data.SetId(dashboard.Id)
 
-	diags = dashboardToResourceData(dashboard, data, true)
+	diags = dashboardToResourceData(dashboard, data)
 	if diags.HasError() {
 		return diags
 	}

--- a/observe/data_source_dataset.go
+++ b/observe/data_source_dataset.go
@@ -165,7 +165,6 @@ func dataSourceDataset() *schema.Resource {
 				},
 			},
 			"object_tags": objectTagsSchemaFieldComputed(),
-			"entity_tags": entityTagsSchemaFieldComputed(),
 		},
 	}
 }
@@ -204,7 +203,7 @@ func dataSourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta 
 	}
 	data.SetId(d.Id)
 
-	diags = datasetToResourceData(d, data, true)
+	diags = datasetToResourceData(d, data)
 	if d.CorrelationTagMappings != nil {
 		var cts []interface{}
 		for _, ct := range d.CorrelationTagMappings {

--- a/observe/data_source_worksheet.go
+++ b/observe/data_source_worksheet.go
@@ -51,7 +51,6 @@ func dataSourceWorksheet() *schema.Resource {
 				Description: schemaWorksheetJSONDescription,
 			},
 			"object_tags": objectTagsSchemaFieldComputed(),
-			"entity_tags": entityTagsSchemaFieldComputed(),
 		},
 	}
 }
@@ -69,5 +68,5 @@ func dataSourceWorksheetRead(ctx context.Context, data *schema.ResourceData, met
 	}
 	data.SetId(ws.Id)
 
-	return worksheetToResourceData(ws, data, true)
+	return worksheetToResourceData(ws, data)
 }

--- a/observe/object_tags.go
+++ b/observe/object_tags.go
@@ -68,19 +68,6 @@ func objectTagsSchemaFieldComputed() *schema.Schema {
 	}
 }
 
-// entityTagsSchemaFieldComputed returns deprecated entity_tags for data sources.
-func entityTagsSchemaFieldComputed() *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeMap,
-		Computed:    true,
-		Description: entityTagsDescription,
-		Deprecated:  entityTagsDeprecatedMessage,
-		Elem: &schema.Schema{
-			Type: schema.TypeString,
-		},
-	}
-}
-
 // objectTagsInputFromReader reads tags for Create/Update API calls.
 // Prefers entity_tags when set in config, matching the SDK v2 optional rename guide.
 func objectTagsInputFromReader(r objectTagsReader) []gql.ObjectTagMappingInput {
@@ -154,40 +141,19 @@ func entityTagsDeprecationDiags(r objectTagsReader) diag.Diagnostics {
 
 // setObjectTagsFromAPI writes tag values from the API into state and returns
 // deprecation warnings for resources using entity_tags.
-func setObjectTagsFromAPI(data *schema.ResourceData, tags []gql.ObjectTagMapping, mirrorDeprecatedTag bool) (diag.Diagnostics, error) {
-	var err error
-	if mirrorDeprecatedTag {
-		err = setObjectTagsOnDataSourceData(data, tags)
-	} else {
-		err = setObjectTagsOnResourceData(data, tags)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if mirrorDeprecatedTag {
-		return nil, nil
-	}
-	return entityTagsDeprecationDiags(data), nil
-}
-
-// setObjectTagsOnResourceData writes API tag values into state on the attribute the
-// practitioner configured (entity_tags preferred), matching the SDK v2 optional rename guide.
-func setObjectTagsOnResourceData(data *schema.ResourceData, tags []gql.ObjectTagMapping) error {
+func setObjectTagsFromAPI(data *schema.ResourceData, tags []gql.ObjectTagMapping) (diag.Diagnostics, error) {
 	flat := flattenObjectTagsToMap(tags)
 	field := activeObjectTagsField(data)
 	if field == "" {
 		field = "object_tags"
 	}
-	return data.Set(field, flat)
-}
-
-// setObjectTagsOnDataSourceData writes both attributes for computed rename compatibility.
-func setObjectTagsOnDataSourceData(data *schema.ResourceData, tags []gql.ObjectTagMapping) error {
-	flat := flattenObjectTagsToMap(tags)
-	if err := data.Set("object_tags", flat); err != nil {
-		return err
+	if err := data.Set(field, flat); err != nil {
+		return nil, err
 	}
-	return data.Set("entity_tags", flat)
+	if field == "entity_tags" {
+		return entityTagsDeprecationDiags(data), nil
+	}
+	return nil, nil
 }
 
 // parseCSVValues parses a CSV string and trims whitespace from each value.

--- a/observe/resource_bookmark.go
+++ b/observe/resource_bookmark.go
@@ -96,7 +96,7 @@ func newBookmarkConfig(data *schema.ResourceData) (input *gql.BookmarkInput, dia
 	return input, diags
 }
 
-func bookmarkToResourceData(b *gql.Bookmark, data *schema.ResourceData, mirrorDeprecatedTag bool) (diags diag.Diagnostics) {
+func bookmarkToResourceData(b *gql.Bookmark, data *schema.ResourceData) (diags diag.Diagnostics) {
 	if err := data.Set("name", b.Name); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -131,7 +131,7 @@ func bookmarkToResourceData(b *gql.Bookmark, data *schema.ResourceData, mirrorDe
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	if tagDiags, err := setObjectTagsFromAPI(data, b.ObjectTags, mirrorDeprecatedTag); err != nil {
+	if tagDiags, err := setObjectTagsFromAPI(data, b.ObjectTags); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	} else {
 		diags = append(diags, tagDiags...)
@@ -177,7 +177,7 @@ func resourceBookmarkRead(ctx context.Context, data *schema.ResourceData, meta i
 		})
 	}
 
-	return bookmarkToResourceData(result, data, false)
+	return bookmarkToResourceData(result, data)
 }
 
 func resourceBookmarkUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -198,7 +198,7 @@ func resourceBookmarkUpdate(ctx context.Context, data *schema.ResourceData, meta
 		return diags
 	}
 
-	return bookmarkToResourceData(result, data, false)
+	return bookmarkToResourceData(result, data)
 }
 
 func resourceBookmarkDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_dashboard.go
+++ b/observe/resource_dashboard.go
@@ -151,7 +151,7 @@ func newDashboardConfig(data *schema.ResourceData) (input *gql.DashboardInput, d
 	return input, diags
 }
 
-func dashboardToResourceData(d *gql.Dashboard, data *schema.ResourceData, mirrorDeprecatedTag bool) (diags diag.Diagnostics) {
+func dashboardToResourceData(d *gql.Dashboard, data *schema.ResourceData) (diags diag.Diagnostics) {
 	if err := data.Set("workspace", oid.WorkspaceOid(d.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -215,7 +215,7 @@ func dashboardToResourceData(d *gql.Dashboard, data *schema.ResourceData, mirror
 		}
 	}
 
-	if tagDiags, err := setObjectTagsFromAPI(data, d.ObjectTags, mirrorDeprecatedTag); err != nil {
+	if tagDiags, err := setObjectTagsFromAPI(data, d.ObjectTags); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	} else {
 		diags = append(diags, tagDiags...)
@@ -269,7 +269,7 @@ func resourceDashboardRead(ctx context.Context, data *schema.ResourceData, meta 
 		})
 	}
 
-	return dashboardToResourceData(result, data, false)
+	return dashboardToResourceData(result, data)
 }
 
 func resourceDashboardUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -294,7 +294,7 @@ func resourceDashboardUpdate(ctx context.Context, data *schema.ResourceData, met
 		return diags
 	}
 
-	return dashboardToResourceData(result, data, false)
+	return dashboardToResourceData(result, data)
 }
 
 func resourceDashboardDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -338,7 +338,7 @@ func newDatasetConfig(data ResourceReader) (*gql.DatasetInput, *gql.MultiStageQu
 	return input, query, diags
 }
 
-func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData, mirrorDeprecatedTag bool) (diags diag.Diagnostics) {
+func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData) (diags diag.Diagnostics) {
 	if err := data.Set("workspace", oid.WorkspaceOid(d.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -401,7 +401,7 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData, mirrorDepr
 		}
 	}
 
-	if tagDiags, err := setObjectTagsFromAPI(data, d.ObjectTags, mirrorDeprecatedTag); err != nil {
+	if tagDiags, err := setObjectTagsFromAPI(data, d.ObjectTags); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	} else {
 		diags = append(diags, tagDiags...)
@@ -535,7 +535,7 @@ func resourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta in
 		})
 	}
 
-	return datasetToResourceData(result, data, false)
+	return datasetToResourceData(result, data)
 }
 
 func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -601,7 +601,7 @@ func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta 
 		diags = append(diags, diagInefficientAcceleration)
 	}
 
-	return append(diags, datasetToResourceData(result, data, false)...)
+	return append(diags, datasetToResourceData(result, data)...)
 }
 
 func resourceDatasetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_worksheet.go
+++ b/observe/resource_worksheet.go
@@ -95,7 +95,7 @@ func newWorksheetConfig(data *schema.ResourceData) (input *gql.WorksheetInput, d
 	return input, diags
 }
 
-func worksheetToResourceData(d *gql.Worksheet, data *schema.ResourceData, mirrorDeprecatedTag bool) (diags diag.Diagnostics) {
+func worksheetToResourceData(d *gql.Worksheet, data *schema.ResourceData) (diags diag.Diagnostics) {
 	if err := data.Set("workspace", oid.WorkspaceOid(d.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -135,7 +135,7 @@ func worksheetToResourceData(d *gql.Worksheet, data *schema.ResourceData, mirror
 		}
 	}
 
-	if tagDiags, err := setObjectTagsFromAPI(data, d.ObjectTags, mirrorDeprecatedTag); err != nil {
+	if tagDiags, err := setObjectTagsFromAPI(data, d.ObjectTags); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	} else {
 		diags = append(diags, tagDiags...)
@@ -189,7 +189,7 @@ func resourceWorksheetRead(ctx context.Context, data *schema.ResourceData, meta 
 		})
 	}
 
-	return worksheetToResourceData(result, data, false)
+	return worksheetToResourceData(result, data)
 }
 
 func resourceWorksheetUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -214,7 +214,7 @@ func resourceWorksheetUpdate(ctx context.Context, data *schema.ResourceData, met
 		return diags
 	}
 
-	return worksheetToResourceData(result, data, false)
+	return worksheetToResourceData(result, data)
 }
 
 func resourceWorksheetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {


### PR DESCRIPTION
Data sources previously mirrored entity_tags alongside object_tags. Removing it prevents resource configs generated from data source from triggering ConflictsWith that we have in resource schemas  when both entity_tags and object_tags are specified together.