### PR TITLE
feat(dataset): add omit-dataset-oid-version flag to stop OID version cascade

### DIFF
--- a/observe/data_source_dataset.go
+++ b/observe/data_source_dataset.go
@@ -203,7 +203,7 @@ func dataSourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta 
 	}
 	data.SetId(d.Id)
 
-	diags = datasetToResourceData(d, data)
+	diags = datasetToResourceData(d, data, client.Flags[flagOmitDatasetOIDVersion])
 	if d.CorrelationTagMappings != nil {
 		var cts []interface{}
 		for _, ct := range d.CorrelationTagMappings {

--- a/observe/helpers.go
+++ b/observe/helpers.go
@@ -299,6 +299,22 @@ func convertFlags(s string) (map[string]bool, error) {
 	return flags, nil
 }
 
+// setDatasetOID writes a dataset oid into resource state.
+func setDatasetOID(data *schema.ResourceData, id *oid.OID, omitVersion bool) error {
+	// Default behavior: always write the current versioned oid.
+	if !omitVersion {
+		return data.Set("oid", id.String())
+	}
+	// omit-dataset-oid-version: If it's the first time we're writing this (new resource), then
+	// write a version-free oid. If there's already an existing oid, then leave it as is, freezing
+	// the version in place, keeping downstream inputs stable.
+	if data.Get("oid").(string) == "" {
+		id.Version = nil
+		return data.Set("oid", id.String())
+	}
+	return nil
+}
+
 // determine whether we expect a new dataset version
 func datasetRecomputeOID(d *schema.ResourceDiff) bool {
 	if len(d.GetChangedKeysPrefix("")) > 0 {

--- a/observe/provider.go
+++ b/observe/provider.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	flagCacheClient       = "cache-client"
-	tfSourceFormatDefault = "terraform/%s"
+	flagCacheClient           = "cache-client"
+	flagOmitDatasetOIDVersion = "omit-dataset-oid-version"
+	tfSourceFormatDefault     = "terraform/%s"
 )
 
 // Provider returns observe terraform provider

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -198,10 +198,10 @@ type ResourceReader interface {
 
 func resourceDatasetCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	client := meta.(*observe.Client)
+	omitVersion := client.Flags[flagOmitDatasetOIDVersion]
 
-	if datasetRecomputeOID(d) {
-		err := d.SetNewComputed("oid")
-		if err != nil {
+	if !omitVersion && datasetRecomputeOID(d) {
+		if err := d.SetNewComputed("oid"); err != nil {
 			return err
 		}
 	}
@@ -338,7 +338,7 @@ func newDatasetConfig(data ResourceReader) (*gql.DatasetInput, *gql.MultiStageQu
 	return input, query, diags
 }
 
-func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData) (diags diag.Diagnostics) {
+func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData, omitVersion bool) (diags diag.Diagnostics) {
 	if err := data.Set("workspace", oid.WorkspaceOid(d.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -418,7 +418,7 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData) (diags dia
 		}
 	}
 
-	if err := data.Set("oid", d.Oid().String()); err != nil {
+	if err := setDatasetOID(data, d.Oid(), omitVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
@@ -535,7 +535,7 @@ func resourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta in
 		})
 	}
 
-	return datasetToResourceData(result, data)
+	return datasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])
 }
 
 func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -601,7 +601,7 @@ func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta 
 		diags = append(diags, diagInefficientAcceleration)
 	}
 
-	return append(diags, datasetToResourceData(result, data)...)
+	return append(diags, datasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])...)
 }
 
 func resourceDatasetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -590,7 +590,9 @@ func TestAccObserveDatasetDefaultRematerializationMode(t *testing.T) {
 		}
 	`
 
-	resource.ParallelTest(t, resource.TestCase{
+	// Serial: overriding provider config mutates the shared testAccProvider
+	// instance, so this cannot run alongside other tests.
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -1459,6 +1461,209 @@ func TestAccObserveDatasetNoWorkspace(t *testing.T) {
 
 					stage {}
 				}`, randomPrefix)),
+		},
+	})
+}
+
+// oidVersionedRegex matches a dataset oid that carries a version suffix, e.g.
+// o:::dataset:12345/2024-03-15T10:22:00Z (legacy behavior, flag off).
+var oidVersionedRegex = regexp.MustCompile(`^o:::dataset:\d+/.+$`)
+
+// oidVersionFreeRegex matches a dataset oid with no version suffix, e.g.
+// o:::dataset:12345 (produced on first write when omit-dataset-oid-version is on).
+var oidVersionFreeRegex = regexp.MustCompile(`^o:::dataset:\d+$`)
+
+// TestAccObserveDatasetOmitOIDVersionNewResources verifies that datasets created
+// from scratch with the omit-dataset-oid-version flag enabled get a version-free
+// oid, and that editing an upstream dataset does not cascade a new version onto
+// its downstream dependents.
+func TestAccObserveDatasetOmitOIDVersionNewResources(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+
+	// The test framework emits our config verbatim only when it contains a
+	// "terraform {" block; otherwise it mangles it by injecting resources.
+	providerOn := `
+		terraform {}
+		provider "observe" {
+			flags = "omit-dataset-oid-version"
+		}
+	`
+
+	// datasetChain builds an A -> B chain where B's inputs reference A's oid.
+	// aPipeline lets us mutate A between steps to exercise the (non-)cascade.
+	datasetChain := func(aPipeline string) string {
+		return fmt.Sprintf(providerOn+configPreamble+datastreamConfigPreamble+`
+		resource "observe_dataset" "a" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-A"
+
+			inputs = { "test" = observe_datastream.test.dataset }
+
+			stage {
+				pipeline = <<-EOF
+					%[2]s
+				EOF
+			}
+		}
+
+		resource "observe_dataset" "b" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-B"
+
+			inputs = { "a" = observe_dataset.a.oid }
+
+			stage {
+				pipeline = <<-EOF
+					filter true
+				EOF
+			}
+		}`, randomPrefix, aPipeline)
+	}
+
+	var bOID string
+
+	// Serial: overriding provider config mutates the shared testAccProvider
+	// instance, so this cannot run alongside other tests.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: datasetChain("make_col x:1"),
+				Check: resource.ComposeTestCheckFunc(
+					// oids are written without a version suffix on first create.
+					resource.TestMatchResourceAttr("observe_dataset.a", "oid", oidVersionFreeRegex),
+					resource.TestMatchResourceAttr("observe_dataset.b", "oid", oidVersionFreeRegex),
+					// B's reference to A resolves to A's version-free oid.
+					resource.TestMatchResourceAttr("observe_dataset.b", "inputs.a", oidVersionFreeRegex),
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						bOID = v
+						return nil
+					}),
+				),
+			},
+			{
+				// Edit A. Without the flag this would bump A's oid version and
+				// cascade a new version onto B; with the flag B must be untouched.
+				Config: datasetChain("make_col x:2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("observe_dataset.a", "oid", oidVersionFreeRegex),
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						if v != bOID {
+							return fmt.Errorf("downstream dataset oid changed (cascade not suppressed): was %q, now %q", bOID, v)
+						}
+						return nil
+					}),
+				),
+			},
+			// Re-plan must be empty: a frozen oid produces no phantom diffs.
+			testAccPlanOnlyNoDriftStep(datasetChain("make_col x:2")),
+		},
+	})
+}
+
+// TestAccObserveDatasetOmitOIDVersionMigration exercises the customer upgrade
+// path: datasets are created with the flag OFF (versioned oids in state), then
+// the flag is toggled ON. Toggling must be a no-op (no plan diff), and a
+// subsequent upstream edit must not cascade onto downstream dependents.
+func TestAccObserveDatasetOmitOIDVersionMigration(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+
+	providerOff := `
+		terraform {}
+		provider "observe" {}
+	`
+	providerOn := `
+		terraform {}
+		provider "observe" {
+			flags = "omit-dataset-oid-version"
+		}
+	`
+
+	datasetChain := func(provider, aPipeline string) string {
+		return fmt.Sprintf(provider+configPreamble+datastreamConfigPreamble+`
+		resource "observe_dataset" "a" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-A"
+
+			inputs = { "test" = observe_datastream.test.dataset }
+
+			stage {
+				pipeline = <<-EOF
+					%[2]s
+				EOF
+			}
+		}
+
+		resource "observe_dataset" "b" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-B"
+
+			inputs = { "a" = observe_dataset.a.oid }
+
+			stage {
+				pipeline = <<-EOF
+					filter true
+				EOF
+			}
+		}`, randomPrefix, aPipeline)
+	}
+
+	var aOID, bOID string
+
+	// Serial: overriding provider config mutates the shared testAccProvider
+	// instance, and this test also changes that config between steps.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Legacy behavior: created with the flag off, oids carry a version.
+				Config: datasetChain(providerOff, "make_col x:1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("observe_dataset.a", "oid", oidVersionedRegex),
+					resource.TestCheckResourceAttrWith("observe_dataset.a", "oid", func(v string) error {
+						aOID = v
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						bOID = v
+						return nil
+					}),
+				),
+			},
+			{
+				// Toggle the flag on with no config change. The existing versioned
+				// oids are frozen in place, so this must be a pure no-op.
+				Config: datasetChain(providerOn, "make_col x:1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("observe_dataset.a", "oid", func(v string) error {
+						if v != aOID {
+							return fmt.Errorf("upstream oid changed on flag toggle: was %q, now %q", aOID, v)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						if v != bOID {
+							return fmt.Errorf("downstream oid changed on flag toggle: was %q, now %q", bOID, v)
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				// Edit A now that the flag is on. B must not get a cascaded version.
+				Config: datasetChain(providerOn, "make_col x:2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						if v != bOID {
+							return fmt.Errorf("downstream dataset oid changed (cascade not suppressed): was %q, now %q", bOID, v)
+						}
+						return nil
+					}),
+				),
+			},
+			testAccPlanOnlyNoDriftStep(datasetChain(providerOn, "make_col x:2")),
 		},
 	})
 }

--- a/observe/resource_log_derived_metric_dataset.go
+++ b/observe/resource_log_derived_metric_dataset.go
@@ -163,8 +163,9 @@ func resourceLogDerivedMetricDataset() *schema.Resource {
 
 func resourceLogDerivedMetricDatasetCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	client := meta.(*observe.Client)
+	omitVersion := client.Flags[flagOmitDatasetOIDVersion]
 
-	if datasetRecomputeOID(d) {
+	if !omitVersion && datasetRecomputeOID(d) {
 		if err := d.SetNewComputed("oid"); err != nil {
 			return err
 		}
@@ -348,7 +349,7 @@ func previousLDMInputOIDVersion(data *schema.ResourceData, datasetID string) *st
 	return prevOID.Version
 }
 
-func logDerivedMetricDatasetToResourceData(d *gql.LogDerivedMetricDataset, data *schema.ResourceData) diag.Diagnostics {
+func logDerivedMetricDatasetToResourceData(d *gql.LogDerivedMetricDataset, data *schema.ResourceData, omitVersion bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if d.LogDerivedMetricTable == nil {
@@ -436,7 +437,7 @@ func logDerivedMetricDatasetToResourceData(d *gql.LogDerivedMetricDataset, data 
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	if err := data.Set("oid", d.Oid().String()); err != nil {
+	if err := setDatasetOID(data, d.Oid(), omitVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
@@ -473,7 +474,7 @@ func resourceLogDerivedMetricDatasetRead(ctx context.Context, data *schema.Resou
 		}
 		return diag.Errorf("failed to read log-derived metric dataset: %s", err)
 	}
-	return logDerivedMetricDatasetToResourceData(d, data)
+	return logDerivedMetricDatasetToResourceData(d, data, client.Flags[flagOmitDatasetOIDVersion])
 }
 
 func resourceLogDerivedMetricDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -495,7 +496,7 @@ func resourceLogDerivedMetricDatasetUpdate(ctx context.Context, data *schema.Res
 		return diag.Errorf("failed to update log-derived metric dataset: %s", err)
 	}
 
-	return logDerivedMetricDatasetToResourceData(result, data)
+	return logDerivedMetricDatasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])
 }
 
 func resourceLogDerivedMetricDatasetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/observe/resource_log_derived_metric_dataset_test.go
+++ b/observe/resource_log_derived_metric_dataset_test.go
@@ -441,7 +441,7 @@ func TestLogDerivedMetricDatasetToResourceData_PreservesInputOIDVersion(t *testi
 		},
 	}
 
-	diags := logDerivedMetricDatasetToResourceData(result, data)
+	diags := logDerivedMetricDatasetToResourceData(result, data, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diags: %v", diags)
 	}

--- a/observe/resource_source_dataset.go
+++ b/observe/resource_source_dataset.go
@@ -68,7 +68,8 @@ func resourceSourceDataset() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-			if datasetRecomputeOID(d) {
+			omitVersion := meta.(*observe.Client).Flags[flagOmitDatasetOIDVersion]
+			if !omitVersion && datasetRecomputeOID(d) {
 				return d.SetNewComputed("oid")
 			}
 			return nil


### PR DESCRIPTION
## Problem

Dataset OIDs embed a version timestamp that advances on every save. Because downstream datasets reference upstream OIDs in their `inputs`, a single upstream save marks the OID as "known after apply" — forcing every downstream dataset to re-plan and re-save. On large dependency graphs this produces many redundant `SaveDataset` calls per apply.

## Fix

The opt-in `omit-dataset-oid-version` flag (set via `OBSERVE_FLAGS` or the provider `flags` attribute) breaks the cascade two ways:

- **CustomizeDiff**: skips `SetNewComputed("oid")` when the flag is on, keeping the upstream OID concrete during downstream planning.
- **setDatasetOID**: writes a version-free OID on first create/import, then freezes it on subsequent reads. Toggling the flag on over existing versioned state is a no-op, so rollout doesn't trigger a one-time diff on every dataset.

Covers `observe_dataset`, `observe_log_derived_metric_dataset`, and `observe_source_dataset`. Default behavior (flag off) is unchanged.

## Testing

Two acceptance tests:

- **Fresh create**: creates an A→B chain with the flag on, asserts version-free OIDs, edits A and asserts B does not re-plan.
- **Migration**: creates A→B with the flag off (versioned OIDs), toggles the flag on and asserts no diff, then edits A and asserts B does not re-plan.