### PR TITLE
feat(dataset): surface downstream compile breaks as Terraform warnings

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -72,7 +72,7 @@ func (c *Client) GetDataset(ctx context.Context, id string) (*meta.Dataset, erro
 	return c.Meta.GetDataset(ctx, id)
 }
 
-func (c *Client) SaveDataset(ctx context.Context, wsid string, input *meta.DatasetInput, queryInput *meta.MultiStageQueryInput, dependencyHandling *meta.DependencyHandlingInput) (*meta.Dataset, error) {
+func (c *Client) SaveDataset(ctx context.Context, wsid string, input *meta.DatasetInput, queryInput *meta.MultiStageQueryInput, dependencyHandling *meta.DependencyHandlingInput) (*meta.DatasetSaveResult, error) {
 	if !c.Flags[flagObs2110] {
 		c.obs2110.Lock()
 		defer c.obs2110.Unlock()
@@ -113,7 +113,7 @@ func (c *Client) DeleteDataset(ctx context.Context, id string) error {
 	return c.Meta.DeleteDataset(ctx, id)
 }
 
-func (c *Client) SaveLogDerivedMetricDataset(ctx context.Context, wsid string, input *meta.DatasetInput, ldmInput *meta.LogDerivedMetricDefinitionInput, dependencyHandling *meta.DependencyHandlingInput) (*meta.LogDerivedMetricDataset, error) {
+func (c *Client) SaveLogDerivedMetricDataset(ctx context.Context, wsid string, input *meta.DatasetInput, ldmInput *meta.LogDerivedMetricDefinitionInput, dependencyHandling *meta.DependencyHandlingInput) (*meta.LogDerivedMetricDatasetSaveResult, error) {
 	if !c.Flags[flagObs2110] {
 		c.obs2110.Lock()
 		defer c.obs2110.Unlock()

--- a/client/internal/meta/operation/dataset.graphql
+++ b/client/internal/meta/operation/dataset.graphql
@@ -78,6 +78,10 @@ fragment Dataset on Dataset {
 		key
 		values
 	}
+	compilationError {
+		error
+		errorInDatasetId
+	}
 }
 
 fragment DatasetIdName on Dataset {

--- a/client/internal/meta/operation/log_derived_metrics.graphql
+++ b/client/internal/meta/operation/log_derived_metrics.graphql
@@ -40,6 +40,10 @@ fragment LogDerivedMetricDataset on Dataset {
 	logDerivedMetricTable {
 		...LogDerivedMetricDefinition
 	}
+	compilationError {
+		error
+		errorInDatasetId
+	}
 }
 
 fragment LogDerivedMetricDatasetSaveResult on DatasetSaveResult {

--- a/client/meta/dataset.go
+++ b/client/meta/dataset.go
@@ -30,10 +30,14 @@ func DefaultDependencyHandling() *DependencyHandlingInput {
 	return &DependencyHandlingInput{SaveMode: &mode}
 }
 
-// SaveDataset creates and updates datasets
-func (client *Client) SaveDataset(ctx context.Context, workspaceId string, input *DatasetInput, queryInput *MultiStageQueryInput, dependencyHandling *DependencyHandlingInput) (*Dataset, error) {
+// SaveDataset creates or updates a dataset and returns the full save result,
+// including any downstream errorDatasets populated by the backend's dependency walk.
+func (client *Client) SaveDataset(ctx context.Context, workspaceId string, input *DatasetInput, queryInput *MultiStageQueryInput, dependencyHandling *DependencyHandlingInput) (*DatasetSaveResult, error) {
 	resp, err := saveDataset(ctx, client.Gql, workspaceId, *input, *queryInput, dependencyHandling)
-	return datasetOrError(resp.DatasetSaveResult, err)
+	if err != nil {
+		return nil, err
+	}
+	return resp.DatasetSaveResult, nil
 }
 
 // SaveDatasetDryRun saves a dataset with pre-flight checks - this is useful when rematerialization_mode is set to "skip_rematerialization"
@@ -112,13 +116,14 @@ func (d *Dataset) Oid() *oid.OID {
 	}
 }
 
-// SaveLogDerivedMetricDataset creates or updates a log-derived metric dataset.
-func (client *Client) SaveLogDerivedMetricDataset(ctx context.Context, workspaceId string, input *DatasetInput, ldmInput *LogDerivedMetricDefinitionInput, dependencyHandling *DependencyHandlingInput) (*LogDerivedMetricDataset, error) {
+// SaveLogDerivedMetricDataset creates or updates a log-derived metric dataset and
+// returns the full save result, including any downstream errorDatasets.
+func (client *Client) SaveLogDerivedMetricDataset(ctx context.Context, workspaceId string, input *DatasetInput, ldmInput *LogDerivedMetricDefinitionInput, dependencyHandling *DependencyHandlingInput) (*LogDerivedMetricDatasetSaveResult, error) {
 	resp, err := saveLogDerivedMetricDataset(ctx, client.Gql, workspaceId, *input, *ldmInput, dependencyHandling)
 	if err != nil {
 		return nil, err
 	}
-	return resp.DatasetSaveResult.Dataset, nil
+	return resp.DatasetSaveResult, nil
 }
 
 // SaveLogDerivedMetricDatasetDryRun performs a preflight check for a log-derived metric dataset save.

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -1330,7 +1330,8 @@ type Dataset struct {
 	SourceTable                *DatasetSourceTableSourceTableDefinition             `json:"sourceTable"`
 	CorrelationTagMappings     []DatasetCorrelationTagMappingsCorrelationTagMapping `json:"correlationTagMappings"`
 	// Object tags for organizing and categorizing datasets.
-	ObjectTags []ObjectTagMapping `json:"objectTags"`
+	ObjectTags       []ObjectTagMapping       `json:"objectTags"`
+	CompilationError *DatasetCompilationError `json:"compilationError"`
 }
 
 // GetWorkspaceId returns Dataset.WorkspaceId, and is useful for accessing the field via an interface.
@@ -1408,6 +1409,27 @@ func (v *Dataset) GetCorrelationTagMappings() []DatasetCorrelationTagMappingsCor
 
 // GetObjectTags returns Dataset.ObjectTags, and is useful for accessing the field via an interface.
 func (v *Dataset) GetObjectTags() []ObjectTagMapping { return v.ObjectTags }
+
+// GetCompilationError returns Dataset.CompilationError, and is useful for accessing the field via an interface.
+func (v *Dataset) GetCompilationError() *DatasetCompilationError { return v.CompilationError }
+
+// DatasetCompilationError includes the requested fields of the GraphQL type CompilationError.
+// The GraphQL type's documentation follows.
+//
+// A dataset could fail to compile either because its OPAL was wrong or
+// because one of its dependencies' OPAL was wrong. CompilationError of
+// a dataset tells you the compilation error string and also where the
+// error originated.
+type DatasetCompilationError struct {
+	Error            string `json:"error"`
+	ErrorInDatasetId string `json:"errorInDatasetId"`
+}
+
+// GetError returns DatasetCompilationError.Error, and is useful for accessing the field via an interface.
+func (v *DatasetCompilationError) GetError() string { return v.Error }
+
+// GetErrorInDatasetId returns DatasetCompilationError.ErrorInDatasetId, and is useful for accessing the field via an interface.
+func (v *DatasetCompilationError) GetErrorInDatasetId() string { return v.ErrorInDatasetId }
 
 // DatasetCorrelationTagMappingsCorrelationTagMapping includes the requested fields of the GraphQL type CorrelationTagMapping.
 type DatasetCorrelationTagMappingsCorrelationTagMapping struct {
@@ -3388,15 +3410,16 @@ func (v *LogDerivedMetricAggregationInput) GetFieldPath() *MetricTagPathInput { 
 
 // LogDerivedMetricDataset includes the GraphQL fields of Dataset requested by the fragment LogDerivedMetricDataset.
 type LogDerivedMetricDataset struct {
-	Id                    string                      `json:"id"`
-	WorkspaceId           string                      `json:"workspaceId"`
-	Name                  string                      `json:"name"`
-	LastSaved             types.TimeScalar            `json:"lastSaved"`
-	Description           *string                     `json:"description"`
-	IconUrl               *string                     `json:"iconUrl"`
-	Source                *string                     `json:"source"`
-	ManagedById           *string                     `json:"managedById"`
-	LogDerivedMetricTable *LogDerivedMetricDefinition `json:"logDerivedMetricTable"`
+	Id                    string                                   `json:"id"`
+	WorkspaceId           string                                   `json:"workspaceId"`
+	Name                  string                                   `json:"name"`
+	LastSaved             types.TimeScalar                         `json:"lastSaved"`
+	Description           *string                                  `json:"description"`
+	IconUrl               *string                                  `json:"iconUrl"`
+	Source                *string                                  `json:"source"`
+	ManagedById           *string                                  `json:"managedById"`
+	LogDerivedMetricTable *LogDerivedMetricDefinition              `json:"logDerivedMetricTable"`
+	CompilationError      *LogDerivedMetricDatasetCompilationError `json:"compilationError"`
 }
 
 // GetId returns LogDerivedMetricDataset.Id, and is useful for accessing the field via an interface.
@@ -3426,6 +3449,31 @@ func (v *LogDerivedMetricDataset) GetManagedById() *string { return v.ManagedByI
 // GetLogDerivedMetricTable returns LogDerivedMetricDataset.LogDerivedMetricTable, and is useful for accessing the field via an interface.
 func (v *LogDerivedMetricDataset) GetLogDerivedMetricTable() *LogDerivedMetricDefinition {
 	return v.LogDerivedMetricTable
+}
+
+// GetCompilationError returns LogDerivedMetricDataset.CompilationError, and is useful for accessing the field via an interface.
+func (v *LogDerivedMetricDataset) GetCompilationError() *LogDerivedMetricDatasetCompilationError {
+	return v.CompilationError
+}
+
+// LogDerivedMetricDatasetCompilationError includes the requested fields of the GraphQL type CompilationError.
+// The GraphQL type's documentation follows.
+//
+// A dataset could fail to compile either because its OPAL was wrong or
+// because one of its dependencies' OPAL was wrong. CompilationError of
+// a dataset tells you the compilation error string and also where the
+// error originated.
+type LogDerivedMetricDatasetCompilationError struct {
+	Error            string `json:"error"`
+	ErrorInDatasetId string `json:"errorInDatasetId"`
+}
+
+// GetError returns LogDerivedMetricDatasetCompilationError.Error, and is useful for accessing the field via an interface.
+func (v *LogDerivedMetricDatasetCompilationError) GetError() string { return v.Error }
+
+// GetErrorInDatasetId returns LogDerivedMetricDatasetCompilationError.ErrorInDatasetId, and is useful for accessing the field via an interface.
+func (v *LogDerivedMetricDatasetCompilationError) GetErrorInDatasetId() string {
+	return v.ErrorInDatasetId
 }
 
 // LogDerivedMetricDatasetSaveResult includes the GraphQL fields of DatasetSaveResult requested by the fragment LogDerivedMetricDatasetSaveResult.
@@ -17737,6 +17785,10 @@ fragment Dataset on Dataset {
 		key
 		values
 	}
+	compilationError {
+		error
+		errorInDatasetId
+	}
 }
 fragment StageQuery on StageQuery {
 	id
@@ -18373,6 +18425,10 @@ fragment LogDerivedMetricDataset on Dataset {
 	managedById
 	logDerivedMetricTable {
 		... LogDerivedMetricDefinition
+	}
+	compilationError {
+		error
+		errorInDatasetId
 	}
 }
 fragment LogDerivedMetricDefinition on LogDerivedMetricDefinition {
@@ -19840,6 +19896,10 @@ fragment Dataset on Dataset {
 		key
 		values
 	}
+	compilationError {
+		error
+		errorInDatasetId
+	}
 }
 fragment StageQuery on StageQuery {
 	id
@@ -20174,6 +20234,10 @@ fragment Dataset on Dataset {
 	objectTags {
 		key
 		values
+	}
+	compilationError {
+		error
+		errorInDatasetId
 	}
 }
 fragment StageQuery on StageQuery {
@@ -21212,6 +21276,10 @@ fragment Dataset on Dataset {
 		key
 		values
 	}
+	compilationError {
+		error
+		errorInDatasetId
+	}
 }
 fragment DatasetError on DatasetError {
 	datasetId
@@ -21347,6 +21415,10 @@ fragment LogDerivedMetricDataset on Dataset {
 	managedById
 	logDerivedMetricTable {
 		... LogDerivedMetricDefinition
+	}
+	compilationError {
+		error
+		errorInDatasetId
 	}
 }
 fragment DatasetError on DatasetError {
@@ -22205,6 +22277,10 @@ fragment Dataset on Dataset {
 	objectTags {
 		key
 		values
+	}
+	compilationError {
+		error
+		errorInDatasetId
 	}
 }
 fragment StageQuery on StageQuery {

--- a/observe/data_source_dataset.go
+++ b/observe/data_source_dataset.go
@@ -203,7 +203,7 @@ func dataSourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta 
 	}
 	data.SetId(d.Id)
 
-	diags = datasetToResourceData(d, data)
+	diags = datasetToResourceData(d, data, false)
 	if d.CorrelationTagMappings != nil {
 		var cts []interface{}
 		for _, ct := range d.CorrelationTagMappings {

--- a/observe/helpers.go
+++ b/observe/helpers.go
@@ -299,6 +299,22 @@ func convertFlags(s string) (map[string]bool, error) {
 	return flags, nil
 }
 
+// setDatasetOID writes a dataset oid into resource state.
+func setDatasetOID(data *schema.ResourceData, id *oid.OID, omitVersion bool) error {
+	// Default behavior: always write the current versioned oid.
+	if !omitVersion {
+		return data.Set("oid", id.String())
+	}
+	// omit-dataset-oid-version: If it's the first time we're writing this (new resource), then
+	// write a version-free oid. If there's already an existing oid, then leave it as is, freezing
+	// the version in place, keeping downstream inputs stable.
+	if data.Get("oid").(string) == "" {
+		id.Version = nil
+		return data.Set("oid", id.String())
+	}
+	return nil
+}
+
 // determine whether we expect a new dataset version
 func datasetRecomputeOID(d *schema.ResourceDiff) bool {
 	if len(d.GetChangedKeysPrefix("")) > 0 {

--- a/observe/provider.go
+++ b/observe/provider.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	flagCacheClient       = "cache-client"
-	tfSourceFormatDefault = "terraform/%s"
+	flagCacheClient           = "cache-client"
+	flagOmitDatasetOIDVersion = "omit-dataset-oid-version"
+	tfSourceFormatDefault     = "terraform/%s"
 )
 
 // Provider returns observe terraform provider

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -198,10 +198,10 @@ type ResourceReader interface {
 
 func resourceDatasetCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	client := meta.(*observe.Client)
+	omitVersion := client.Flags[flagOmitDatasetOIDVersion]
 
-	if datasetRecomputeOID(d) {
-		err := d.SetNewComputed("oid")
-		if err != nil {
+	if !omitVersion && datasetRecomputeOID(d) {
+		if err := d.SetNewComputed("oid"); err != nil {
 			return err
 		}
 	}
@@ -338,7 +338,7 @@ func newDatasetConfig(data ResourceReader) (*gql.DatasetInput, *gql.MultiStageQu
 	return input, query, diags
 }
 
-func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData) (diags diag.Diagnostics) {
+func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData, omitVersion bool) (diags diag.Diagnostics) {
 	if err := data.Set("workspace", oid.WorkspaceOid(d.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -418,7 +418,7 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData) (diags dia
 		}
 	}
 
-	if err := data.Set("oid", d.Oid().String()); err != nil {
+	if err := setDatasetOID(data, d.Oid(), omitVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
@@ -535,7 +535,7 @@ func resourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta in
 		})
 	}
 
-	return datasetToResourceData(result, data)
+	return datasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])
 }
 
 func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -601,7 +601,7 @@ func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta 
 		diags = append(diags, diagInefficientAcceleration)
 	}
 
-	return append(diags, datasetToResourceData(result, data)...)
+	return append(diags, datasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])...)
 }
 
 func resourceDatasetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -502,7 +502,7 @@ func resourceDatasetCreate(ctx context.Context, data *schema.ResourceData, meta 
 	if err != nil {
 		return append(diags, diag.FromErr(err)...)
 	}
-	result, err := client.SaveDataset(ctx, wsid, input, queryInput, dependencyHandling)
+	saveResult, err := client.SaveDataset(ctx, wsid, input, queryInput, dependencyHandling)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -512,11 +512,11 @@ func resourceDatasetCreate(ctx context.Context, data *schema.ResourceData, meta 
 		return diags
 	}
 
-	if result.AccelerationType == gql.AccelerationTypeOther {
+	diags = appendDownstreamWarnings(diags, saveResult.ErrorDatasets)
+	if saveResult.Dataset.AccelerationType == gql.AccelerationTypeOther {
 		diags = append(diags, diagInefficientAcceleration)
 	}
-
-	data.SetId(result.Id)
+	data.SetId(saveResult.Dataset.Id)
 	return append(diags, resourceDatasetRead(ctx, data, meta)...)
 }
 
@@ -535,7 +535,8 @@ func resourceDatasetRead(ctx context.Context, data *schema.ResourceData, meta in
 		})
 	}
 
-	return datasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])
+	diags = appendCompilationWarning(diags, data.Id(), result.CompilationError)
+	return append(diags, datasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])...)
 }
 
 func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -587,7 +588,7 @@ func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta 
 		dependencyHandling.RematerializationMode = &mode
 	}
 
-	result, err := client.SaveDataset(ctx, wsid, input, queryInput, dependencyHandling)
+	saveResult, err := client.SaveDataset(ctx, wsid, input, queryInput, dependencyHandling)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -597,11 +598,11 @@ func resourceDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta 
 		return diags
 	}
 
-	if result.AccelerationType == gql.AccelerationTypeOther {
+	diags = appendDownstreamWarnings(diags, saveResult.ErrorDatasets)
+	if saveResult.Dataset.AccelerationType == gql.AccelerationTypeOther {
 		diags = append(diags, diagInefficientAcceleration)
 	}
-
-	return append(diags, datasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])...)
+	return append(diags, datasetToResourceData(saveResult.Dataset, data, client.Flags[flagOmitDatasetOIDVersion])...)
 }
 
 func resourceDatasetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -652,6 +653,39 @@ func rematerializationErrorStr(dematerializedDatasets []gql.DatasetMaterializati
 	}
 	sb.WriteString(`. If rematerialization is acceptable, remove rematerialization_mode and try again`)
 	return sb.String()
+}
+
+// appendDownstreamWarnings emits a warning diagnostic for each errorDatasets entry that
+// represents a newly-introduced compile break (hasExistingError == false).
+func appendDownstreamWarnings(diags diag.Diagnostics, errorDatasets []gql.DatasetError) diag.Diagnostics {
+	for _, e := range errorDatasets {
+		if !e.HasExistingError {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("downstream dataset %q [id=%s] has a new compile error", e.DatasetName, e.DatasetId),
+				Detail:   e.Text,
+			})
+		}
+	}
+	return diags
+}
+
+// appendCompilationWarning emits a warning diagnostic when a dataset currently has a
+// compilation error, distinguishing between an error in its own OPAL and one inherited
+// from an upstream dependency.
+func appendCompilationWarning(diags diag.Diagnostics, id string, ce *gql.DatasetCompilationError) diag.Diagnostics {
+	if ce == nil {
+		return diags
+	}
+	detail := ce.Error
+	if ce.ErrorInDatasetId != id {
+		detail = fmt.Sprintf("error originates in upstream dataset [id=%s]: %s", ce.ErrorInDatasetId, ce.Error)
+	}
+	return append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  fmt.Sprintf("dataset [id=%s] has a compilation error", id),
+		Detail:   detail,
+	})
 }
 
 func getRematerializationMode(client *observe.Client, data ResourceReader) TerraformRematerializationMode {

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -1462,3 +1462,201 @@ func TestAccObserveDatasetNoWorkspace(t *testing.T) {
 		},
 	})
 }
+
+// oidVersionedRegex matches a dataset oid that carries a version suffix, e.g.
+// o:::dataset:12345/2024-03-15T10:22:00Z (legacy behavior, flag off).
+var oidVersionedRegex = regexp.MustCompile(`^o:::dataset:\d+/.+$`)
+
+// oidVersionFreeRegex matches a dataset oid with no version suffix, e.g.
+// o:::dataset:12345 (produced on first write when omit-dataset-oid-version is on).
+var oidVersionFreeRegex = regexp.MustCompile(`^o:::dataset:\d+$`)
+
+// TestAccObserveDatasetOmitOIDVersionNewResources verifies that datasets created
+// from scratch with the omit-dataset-oid-version flag enabled get a version-free
+// oid, and that editing an upstream dataset does not cascade a new version onto
+// its downstream dependents.
+func TestAccObserveDatasetOmitOIDVersionNewResources(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+
+	// see TestAccObserveDatasetDefaultRematerializationMode for why terraform{} is needed
+	providerOn := `
+		terraform {}
+		provider "observe" {
+			flags = "omit-dataset-oid-version"
+		}
+	`
+
+	// datasetChain builds an A -> B chain where B's inputs reference A's oid.
+	// aPipeline lets us mutate A between steps to exercise the (non-)cascade.
+	datasetChain := func(aPipeline string) string {
+		return fmt.Sprintf(providerOn+configPreamble+datastreamConfigPreamble+`
+		resource "observe_dataset" "a" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-A"
+
+			inputs = { "test" = observe_datastream.test.dataset }
+
+			stage {
+				pipeline = <<-EOF
+					%[2]s
+				EOF
+			}
+		}
+
+		resource "observe_dataset" "b" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-B"
+
+			inputs = { "a" = observe_dataset.a.oid }
+
+			stage {
+				pipeline = <<-EOF
+					filter true
+				EOF
+			}
+		}`, randomPrefix, aPipeline)
+	}
+
+	var bOID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: datasetChain("make_col x:1"),
+				Check: resource.ComposeTestCheckFunc(
+					// oids are written without a version suffix on first create.
+					resource.TestMatchResourceAttr("observe_dataset.a", "oid", oidVersionFreeRegex),
+					resource.TestMatchResourceAttr("observe_dataset.b", "oid", oidVersionFreeRegex),
+					// B's reference to A resolves to A's version-free oid.
+					resource.TestMatchResourceAttr("observe_dataset.b", "inputs.a", oidVersionFreeRegex),
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						bOID = v
+						return nil
+					}),
+				),
+			},
+			{
+				// Edit A. Without the flag this would bump A's oid version and
+				// cascade a new version onto B; with the flag B must be untouched.
+				Config: datasetChain("make_col x:2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("observe_dataset.a", "oid", oidVersionFreeRegex),
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						if v != bOID {
+							return fmt.Errorf("downstream dataset oid changed (cascade not suppressed): was %q, now %q", bOID, v)
+						}
+						return nil
+					}),
+				),
+			},
+			// Re-plan must be empty: a frozen oid produces no phantom diffs.
+			testAccPlanOnlyNoDriftStep(datasetChain("make_col x:2")),
+		},
+	})
+}
+
+// TestAccObserveDatasetOmitOIDVersionMigration exercises the customer upgrade
+// path: datasets are created with the flag OFF (versioned oids in state), then
+// the flag is toggled ON. Toggling must be a no-op (no plan diff), and a
+// subsequent upstream edit must not cascade onto downstream dependents.
+func TestAccObserveDatasetOmitOIDVersionMigration(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+
+	providerOff := `
+		terraform {}
+		provider "observe" {}
+	`
+	providerOn := `
+		terraform {}
+		provider "observe" {
+			flags = "omit-dataset-oid-version"
+		}
+	`
+
+	datasetChain := func(provider, aPipeline string) string {
+		return fmt.Sprintf(provider+configPreamble+datastreamConfigPreamble+`
+		resource "observe_dataset" "a" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-A"
+
+			inputs = { "test" = observe_datastream.test.dataset }
+
+			stage {
+				pipeline = <<-EOF
+					%[2]s
+				EOF
+			}
+		}
+
+		resource "observe_dataset" "b" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-B"
+
+			inputs = { "a" = observe_dataset.a.oid }
+
+			stage {
+				pipeline = <<-EOF
+					filter true
+				EOF
+			}
+		}`, randomPrefix, aPipeline)
+	}
+
+	var aOID, bOID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Legacy behavior: created with the flag off, oids carry a version.
+				Config: datasetChain(providerOff, "make_col x:1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("observe_dataset.a", "oid", oidVersionedRegex),
+					resource.TestCheckResourceAttrWith("observe_dataset.a", "oid", func(v string) error {
+						aOID = v
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						bOID = v
+						return nil
+					}),
+				),
+			},
+			{
+				// Toggle the flag on with no config change. The existing versioned
+				// oids are frozen in place, so this must be a pure no-op.
+				Config: datasetChain(providerOn, "make_col x:1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("observe_dataset.a", "oid", func(v string) error {
+						if v != aOID {
+							return fmt.Errorf("upstream oid changed on flag toggle: was %q, now %q", aOID, v)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						if v != bOID {
+							return fmt.Errorf("downstream oid changed on flag toggle: was %q, now %q", bOID, v)
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				// Edit A now that the flag is on. B must not get a cascaded version.
+				Config: datasetChain(providerOn, "make_col x:2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
+						if v != bOID {
+							return fmt.Errorf("downstream dataset oid changed (cascade not suppressed): was %q, now %q", bOID, v)
+						}
+						return nil
+					}),
+				),
+			},
+			testAccPlanOnlyNoDriftStep(datasetChain(providerOn, "make_col x:2")),
+		},
+	})
+}

--- a/observe/resource_log_derived_metric_dataset.go
+++ b/observe/resource_log_derived_metric_dataset.go
@@ -455,12 +455,13 @@ func resourceLogDerivedMetricDatasetCreate(ctx context.Context, data *schema.Res
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	result, err := client.SaveLogDerivedMetricDataset(ctx, wsid, input, logInput, gql.DefaultDependencyHandling())
+	saveResult, err := client.SaveLogDerivedMetricDataset(ctx, wsid, input, logInput, gql.DefaultDependencyHandling())
 	if err != nil {
 		return diag.Errorf("failed to create log-derived metric dataset: %s", err)
 	}
 
-	data.SetId(result.Id)
+	diags = appendDownstreamWarnings(diags, saveResult.ErrorDatasets)
+	data.SetId(saveResult.Dataset.Id)
 	return append(diags, resourceLogDerivedMetricDatasetRead(ctx, data, meta)...)
 }
 
@@ -474,7 +475,9 @@ func resourceLogDerivedMetricDatasetRead(ctx context.Context, data *schema.Resou
 		}
 		return diag.Errorf("failed to read log-derived metric dataset: %s", err)
 	}
-	return logDerivedMetricDatasetToResourceData(d, data, client.Flags[flagOmitDatasetOIDVersion])
+	var diags diag.Diagnostics
+	diags = appendLDMCompilationWarning(diags, data.Id(), d.CompilationError)
+	return append(diags, logDerivedMetricDatasetToResourceData(d, data, client.Flags[flagOmitDatasetOIDVersion])...)
 }
 
 func resourceLogDerivedMetricDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -491,12 +494,13 @@ func resourceLogDerivedMetricDatasetUpdate(ctx context.Context, data *schema.Res
 		return diag.FromErr(err)
 	}
 
-	result, err := client.SaveLogDerivedMetricDataset(ctx, wsid, input, logInput, gql.DefaultDependencyHandling())
+	saveResult, err := client.SaveLogDerivedMetricDataset(ctx, wsid, input, logInput, gql.DefaultDependencyHandling())
 	if err != nil {
 		return diag.Errorf("failed to update log-derived metric dataset: %s", err)
 	}
 
-	return logDerivedMetricDatasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])
+	diags = appendDownstreamWarnings(diags, saveResult.ErrorDatasets)
+	return append(diags, logDerivedMetricDatasetToResourceData(saveResult.Dataset, data, client.Flags[flagOmitDatasetOIDVersion])...)
 }
 
 func resourceLogDerivedMetricDatasetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -505,4 +509,19 @@ func resourceLogDerivedMetricDatasetDelete(ctx context.Context, data *schema.Res
 		return diag.Errorf("failed to delete log-derived metric dataset: %s", err)
 	}
 	return nil
+}
+
+func appendLDMCompilationWarning(diags diag.Diagnostics, id string, ce *gql.LogDerivedMetricDatasetCompilationError) diag.Diagnostics {
+	if ce == nil {
+		return diags
+	}
+	detail := ce.Error
+	if ce.ErrorInDatasetId != id {
+		detail = fmt.Sprintf("error originates in upstream dataset [id=%s]: %s", ce.ErrorInDatasetId, ce.Error)
+	}
+	return append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  fmt.Sprintf("dataset [id=%s] has a compilation error", id),
+		Detail:   detail,
+	})
 }

--- a/observe/resource_log_derived_metric_dataset.go
+++ b/observe/resource_log_derived_metric_dataset.go
@@ -163,8 +163,9 @@ func resourceLogDerivedMetricDataset() *schema.Resource {
 
 func resourceLogDerivedMetricDatasetCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	client := meta.(*observe.Client)
+	omitVersion := client.Flags[flagOmitDatasetOIDVersion]
 
-	if datasetRecomputeOID(d) {
+	if !omitVersion && datasetRecomputeOID(d) {
 		if err := d.SetNewComputed("oid"); err != nil {
 			return err
 		}
@@ -348,7 +349,7 @@ func previousLDMInputOIDVersion(data *schema.ResourceData, datasetID string) *st
 	return prevOID.Version
 }
 
-func logDerivedMetricDatasetToResourceData(d *gql.LogDerivedMetricDataset, data *schema.ResourceData) diag.Diagnostics {
+func logDerivedMetricDatasetToResourceData(d *gql.LogDerivedMetricDataset, data *schema.ResourceData, omitVersion bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if d.LogDerivedMetricTable == nil {
@@ -436,7 +437,7 @@ func logDerivedMetricDatasetToResourceData(d *gql.LogDerivedMetricDataset, data 
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	if err := data.Set("oid", d.Oid().String()); err != nil {
+	if err := setDatasetOID(data, d.Oid(), omitVersion); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
@@ -473,7 +474,7 @@ func resourceLogDerivedMetricDatasetRead(ctx context.Context, data *schema.Resou
 		}
 		return diag.Errorf("failed to read log-derived metric dataset: %s", err)
 	}
-	return logDerivedMetricDatasetToResourceData(d, data)
+	return logDerivedMetricDatasetToResourceData(d, data, client.Flags[flagOmitDatasetOIDVersion])
 }
 
 func resourceLogDerivedMetricDatasetUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -495,7 +496,7 @@ func resourceLogDerivedMetricDatasetUpdate(ctx context.Context, data *schema.Res
 		return diag.Errorf("failed to update log-derived metric dataset: %s", err)
 	}
 
-	return logDerivedMetricDatasetToResourceData(result, data)
+	return logDerivedMetricDatasetToResourceData(result, data, client.Flags[flagOmitDatasetOIDVersion])
 }
 
 func resourceLogDerivedMetricDatasetDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/observe/resource_log_derived_metric_dataset_test.go
+++ b/observe/resource_log_derived_metric_dataset_test.go
@@ -441,7 +441,7 @@ func TestLogDerivedMetricDatasetToResourceData_PreservesInputOIDVersion(t *testi
 		},
 	}
 
-	diags := logDerivedMetricDatasetToResourceData(result, data)
+	diags := logDerivedMetricDatasetToResourceData(result, data, false)
 	if diags.HasError() {
 		t.Fatalf("unexpected diags: %v", diags)
 	}

--- a/observe/resource_source_dataset.go
+++ b/observe/resource_source_dataset.go
@@ -68,7 +68,8 @@ func resourceSourceDataset() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-			if datasetRecomputeOID(d) {
+			omitVersion := meta.(*observe.Client).Flags[flagOmitDatasetOIDVersion]
+			if !omitVersion && datasetRecomputeOID(d) {
 				return d.SetNewComputed("oid")
 			}
 			return nil


### PR DESCRIPTION
## Summary

When a dataset save breaks a downstream dataset's compilation, or when a dataset itself has a compilation error, Terraform now surfaces these as warnings rather than silently discarding them.

Previously, the provider called `DatasetSaveResult` but threw away the `errorDatasets` list, and `GetDataset`/`GetLogDerivedMetricDataset` never requested `compilationError`. This meant broken downstream datasets were invisible to `terraform apply` and `terraform plan` (read/refresh path).

## Changes

### GQL fragments (`dataset.graphql`, `log_derived_metrics.graphql`)
Added `compilationError { error errorInDatasetId }` to the `Dataset` and `LogDerivedMetricDataset` fragments so `GetDataset` returns compilation state.

### `SaveDataset` / `SaveLogDerivedMetricDataset` return type change
Both methods now return the full `*DatasetSaveResult` / `*LogDerivedMetricDatasetSaveResult` instead of just the inner `*Dataset`. This exposes `ErrorDatasets` to callers without requiring a separate method.

### Apply-time warnings (Create / Update)
After a successful save, `appendDownstreamWarnings` emits a `diag.Warning` for each entry in `ErrorDatasets` where `HasExistingError == false` — i.e., compile breaks this change newly introduced, not ones that were already broken before.

### Read-time warnings (Read / plan refresh)
After `GetDataset`/`GetLogDerivedMetricDataset`, `appendCompilationWarning` / `appendLDMCompilationWarning` emits a warning if `CompilationError` is non-nil, distinguishing between an error in the dataset's own OPAL vs. one inherited from an upstream dependency.