### PR TITLE
feat(worksheet): add cross-tenant export bindings support

### DIFF
--- a/docs/data-sources/worksheet.md
+++ b/docs/data-sources/worksheet.md
@@ -36,6 +36,7 @@ data "observe_worksheet" "lookup" {
 
 ### Read-Only
 
+- `_bindings` (String) Internal field. Do not use.
 - `icon_url` (String) Icon image.
 - `name` (String) Worksheet name. Must be unique within workspace.
 - `object_tags` (Map of String) Object tags for organizing and categorizing workspace objects. Map keys are tag names, values are comma-separated lists. Values are parsed as CSV format for proper escaping. Leading/trailing spaces are automatically trimmed, internal spaces are preserved. Values containing commas must be quoted using CSV escaping.

--- a/observe/data_source_worksheet.go
+++ b/observe/data_source_worksheet.go
@@ -2,10 +2,13 @@ package observe
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	observe "github.com/observeinc/terraform-provider-observe/client"
+	"github.com/observeinc/terraform-provider-observe/client/binding"
+	gql "github.com/observeinc/terraform-provider-observe/client/meta"
 	"github.com/observeinc/terraform-provider-observe/client/oid"
 )
 
@@ -51,6 +54,11 @@ func dataSourceWorksheet() *schema.Resource {
 				Description: schemaWorksheetJSONDescription,
 			},
 			"object_tags": objectTagsSchemaFieldComputed(),
+			"_bindings": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: schemaWorksheetBindingsDescription,
+			},
 		},
 	}
 }
@@ -68,5 +76,50 @@ func dataSourceWorksheetRead(ctx context.Context, data *schema.ResourceData, met
 	}
 	data.SetId(ws.Id)
 
-	return worksheetToResourceData(ws, data)
+	diags = worksheetToResourceData(ws, data)
+	if diags.HasError() {
+		return diags
+	}
+
+	if client.ExportObjectBindings {
+		err := generateWorksheetBindings(ctx, ws, data, client)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return diags
+}
+
+// Generates bindings for use in cross-tenant exports of worksheets. See binding.go for details.
+func generateWorksheetBindings(ctx context.Context, ws *gql.Worksheet, data *schema.ResourceData, client *observe.Client) error {
+	bindFor := binding.NewKindSet(binding.KindDataset, binding.KindWorkspace)
+	gen, err := binding.NewGenerator(ctx, binding.KindWorksheet, ws.Label, client, bindFor)
+	if err != nil {
+		return fmt.Errorf("failed to initialize binding generator: %w", err)
+	}
+
+	workspaceRef, _ := gen.TryBindOid(oid.WorkspaceOid(ws.WorkspaceId))
+	if err := data.Set("workspace", workspaceRef); err != nil {
+		return err
+	}
+
+	queriesJson := data.Get("queries").(string)
+	if queriesJson != "" {
+		queriesWithReferences, err := gen.GenerateJson([]byte(queriesJson))
+		if err != nil {
+			return fmt.Errorf("failed to generate bindings for field 'queries': %w", err)
+		}
+		if err := data.Set("queries", string(queriesWithReferences)); err != nil {
+			return err
+		}
+	}
+
+	bindingsJson, err := gen.GetBindingsJson()
+	if err != nil {
+		return err
+	}
+	if err := data.Set("_bindings", string(bindingsJson)); err != nil {
+		return err
+	}
+	return nil
 }

--- a/observe/data_source_worksheet_test.go
+++ b/observe/data_source_worksheet_test.go
@@ -1,12 +1,104 @@
 package observe
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/observeinc/terraform-provider-observe/client/binding"
 )
+
+func TestAccObserveSourceWorksheet_ExportWithBindings(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+
+	// see TestAccObserveSourceDashboard_ExportWithBindings for context on this trick
+	providerPreamble := `
+		terraform {} # trick the testing framework into not mangling our config
+		provider "observe" {
+			export_object_bindings = true
+		}
+	`
+
+	workspaceTfName := fmt.Sprintf("workspace_%s", strings.ToLower(defaultWorkspaceName))
+	workspaceTfLocalBindingVar := fmt.Sprintf("binding__worksheet_%s__%s", randomPrefix, workspaceTfName)
+	datasetTfName := fmt.Sprintf("worksheet_%s__dataset_%s", randomPrefix, randomPrefix)
+	datasetTfLocalBindingVar := fmt.Sprintf("binding__%s", datasetTfName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(providerPreamble+configPreamble+datastreamConfigPreamble+`
+					data "observe_oid" "dataset" {
+						oid = observe_datastream.test.dataset
+					}
+
+					resource "observe_worksheet" "first" {
+						workspace = data.observe_workspace.default.oid
+						name      = "%[1]s"
+						queries = <<-EOF
+						[{
+							"pipeline": "filter true",
+							"input": [{
+								"inputName": "test",
+								"inputRole": "Data",
+								"datasetId": "${data.observe_oid.dataset.id}"
+							}]
+						}]
+						EOF
+					}
+
+					data "observe_worksheet" "lookup" {
+						id = observe_worksheet.first.id
+					}
+				`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.observe_worksheet.lookup", "workspace", fmt.Sprintf("${local.%s}", workspaceTfLocalBindingVar)),
+					resource.TestCheckResourceAttrWith("data.observe_worksheet.lookup", "queries", func(val string) error {
+						var stagesPartial []struct {
+							Input []struct {
+								DatasetId string `json:"datasetId"`
+							} `json:"input"`
+						}
+						if err := json.Unmarshal([]byte(val), &stagesPartial); err != nil {
+							return err
+						}
+						expectedId := fmt.Sprintf("${local.%s}", datasetTfLocalBindingVar)
+						actualId := stagesPartial[0].Input[0].DatasetId
+						if actualId != expectedId {
+							return fmt.Errorf("expected %#v, got %#v", expectedId, actualId)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("data.observe_worksheet.lookup", "_bindings", func(value string) error {
+						var bindings binding.BindingsObject
+						if err := json.Unmarshal([]byte(value), &bindings); err != nil {
+							return err
+						}
+						expectedKinds := []binding.Kind{binding.KindDataset, binding.KindWorkspace}
+						if !reflect.DeepEqual(bindings.Kinds, expectedKinds) {
+							return fmt.Errorf("bindings.Kinds does not match: expected %#v, got %#v", expectedKinds, bindings.Kinds)
+						}
+						expectedWorkspaceBinding := binding.Target{TfLocalBindingVar: workspaceTfLocalBindingVar, TfName: workspaceTfName, IsOid: true}
+						if bindings.Workspace != expectedWorkspaceBinding {
+							return fmt.Errorf("bindings.Workspace does not match: expected %#v, got %#v", expectedWorkspaceBinding, bindings.Workspace)
+						}
+						expectedDatasetBinding := binding.Target{TfLocalBindingVar: datasetTfLocalBindingVar, TfName: datasetTfName, IsOid: false}
+						if b, ok := bindings.Mappings[binding.Ref{Kind: binding.KindDataset, Key: randomPrefix}]; !ok || b != expectedDatasetBinding {
+							return fmt.Errorf("bindings.Mappings does not contain expected binding %#v for dataset %s, found: %#v", expectedDatasetBinding, randomPrefix, bindings.Mappings)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
 
 func TestAccObserveSourceWorksheet(t *testing.T) {
 	randomPrefix := acctest.RandomWithPrefix("tf")

--- a/observe/resource_worksheet.go
+++ b/observe/resource_worksheet.go
@@ -20,6 +20,7 @@ const (
 	schemaWorksheetIconDescription      = "Icon image."
 	schemaWorksheetJSONDescription      = "Worksheet definition in JSON format."
 	schemaWorksheetOIDDescription       = "The Observe ID for worksheet."
+	schemaWorksheetBindingsDescription  = "Internal field. Do not use."
 )
 
 func resourceWorksheet() *schema.Resource {


### PR DESCRIPTION
## What

Adds a `_bindings` computed field to the `observe_worksheet` data source, enabling cross-tenant Terraform exports for worksheets (parity with `observe_monitor_v2` and `observe_dashboard`).

## How

When `export_object_bindings = true` on the provider, `generateWorksheetBindings` rewrites the workspace OID and all `datasetId` values inside `queries` to `${local.binding__...}` references, then serializes the binding manifest into `_bindings`. `queries` is a JSON string field, so it uses `GenerateJson` — the same path as dashboard `stages`, with `datasetId` already mapped to `KindDataset` by `guessKindFromKey`.

## Testing

`TestAccObserveSourceWorksheet_ExportWithBindings` (acceptance test) verifies the workspace and dataset ID rewrites and deserializes the `_bindings` manifest to confirm the expected kinds and targets.