### PR TITLE
feat(binding): cross-tenant export support for monitor_v2_action

### DIFF
--- a/client/binding/binding.go
+++ b/client/binding/binding.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	observe "github.com/observeinc/terraform-provider-observe/client"
@@ -36,8 +37,8 @@ var (
 )
 
 type ResourceCacheEntry struct {
-	TfName string
-	Label  string
+	TfName    string
+	LookupKey string
 }
 
 type ResourceCache struct {
@@ -60,7 +61,7 @@ func NewResourceCache(ctx context.Context, kinds KindSet, client *observe.Client
 	if err != nil {
 		return cache, err
 	}
-	cache.addEntry(KindWorkspace, workspaces[0].Label, workspaces[0].Oid().String(), false, nil, make(map[string]struct{}))
+	cache.addEntry(KindWorkspace, workspaces[0].Label, workspaces[0].Label, workspaces[0].Oid().String(), false, nil, make(map[string]struct{}))
 	cache.workspaceOid = workspaces[0].Oid()
 	cache.workspaceEntry = cache.LookupId(KindWorkspace, cache.workspaceOid.String())
 
@@ -75,7 +76,7 @@ func NewResourceCache(ctx context.Context, kinds KindSet, client *observe.Client
 				return cache, err
 			}
 			for _, ds := range datasets {
-				cache.addEntry(KindDataset, ds.Name, ds.Id, true, &disambiguator, existingResourceNames)
+				cache.addEntry(KindDataset, ds.Name, ds.Name, ds.Id, true, &disambiguator, existingResourceNames)
 			}
 		case KindWorksheet:
 			worksheets, err := client.ListWorksheetIdLabelOnly(ctx, cache.workspaceOid.Id)
@@ -83,7 +84,7 @@ func NewResourceCache(ctx context.Context, kinds KindSet, client *observe.Client
 				return cache, err
 			}
 			for _, wk := range worksheets {
-				cache.addEntry(KindWorksheet, wk.Label, wk.Id, true, &disambiguator, existingResourceNames)
+				cache.addEntry(KindWorksheet, wk.Label, wk.Label, wk.Id, true, &disambiguator, existingResourceNames)
 			}
 		case KindUser:
 			users, err := client.ListUsers(ctx)
@@ -91,7 +92,10 @@ func NewResourceCache(ctx context.Context, kinds KindSet, client *observe.Client
 				return cache, err
 			}
 			for _, user := range users {
-				cache.addEntry(KindUser, user.Label, user.Id.String(), true, &disambiguator, existingResourceNames)
+				// lookupKey is the email because observe_user is looked up by email, not display name.
+				// Use FormatInt (not user.Id.String()) — String() JSON-quotes the number ("2347"),
+				// but OID parsing captures the bare digits (2347), so the cache keys must match.
+				cache.addEntry(KindUser, user.Email, user.Label, strconv.FormatInt(int64(user.Id), 10), true, &disambiguator, existingResourceNames)
 			}
 		case KindMonitorV2Action:
 			actions, err := client.SearchMonitorV2Action(ctx, &cache.workspaceOid.Id, nil)
@@ -99,15 +103,15 @@ func NewResourceCache(ctx context.Context, kinds KindSet, client *observe.Client
 				return cache, err
 			}
 			for _, action := range actions {
-				cache.addEntry(KindMonitorV2Action, action.Name, action.Id, true, &disambiguator, existingResourceNames)
+				cache.addEntry(KindMonitorV2Action, action.Name, action.Name, action.Id, true, &disambiguator, existingResourceNames)
 			}
 		}
 	}
 	return cache, nil
 }
 
-func (c *ResourceCache) addEntry(kind Kind, label string, id string, addPrefix bool, disambiguator *int, existingNames map[string]struct{}) {
-	resourceName := sanitizeIdentifier(label)
+func (c *ResourceCache) addEntry(kind Kind, lookupKey string, displayName string, id string, addPrefix bool, disambiguator *int, existingNames map[string]struct{}) {
+	resourceName := sanitizeIdentifier(displayName)
 	if _, found := existingNames[resourceName]; found {
 		resourceName = fmt.Sprintf("%s_%d", resourceName, *disambiguator)
 		*disambiguator++
@@ -122,8 +126,8 @@ func (c *ResourceCache) addEntry(kind Kind, label string, id string, addPrefix b
 		tfName = fmt.Sprintf("%s_%s", kind, resourceName)
 	}
 	c.idToLabel[Ref{Kind: kind, Key: id}] = ResourceCacheEntry{
-		TfName: tfName,
-		Label:  label,
+		TfName:    tfName,
+		LookupKey: lookupKey,
 	}
 }
 
@@ -202,7 +206,7 @@ func (g *Generator) tryBind(kind Kind, id string, isOid bool) (maybeRef string, 
 	// process into local var ref
 	insertPrefix := kind == KindWorkspace
 	terraformLocal := g.fmtTfLocalVar(kind, e, insertPrefix)
-	g.bindings[Ref{Kind: kind, Key: e.Label}] = Target{
+	g.bindings[Ref{Kind: kind, Key: e.LookupKey}] = Target{
 		TfName:            e.TfName,
 		TfLocalBindingVar: terraformLocal,
 		IsOid:             isOid,
@@ -213,20 +217,19 @@ func (g *Generator) tryBind(kind Kind, id string, isOid bool) (maybeRef string, 
 // Generate walks the provided data structure and for all ids encountered,
 // generates a binding for it, and replaces the id with a local variable reference
 func (g *Generator) Generate(data interface{}) {
-	mapOverJsonStringKeys(data, func(key string, value string, jsonMapNode map[string]interface{}) {
+	mapOverJsonStringKeys(data, func(key string, value string) string {
 		if valueOid, err := oid.NewOID(value); err == nil {
-			jsonMapNode[key], _ = g.TryBindOid(*valueOid)
-		} else {
-			kinds := guessKindFromKey(key)
-			for _, kind := range kinds {
-				// try bind the name
-				maybeRef, didBind := g.TryBindId(kind, value)
-				if didBind {
-					jsonMapNode[key] = maybeRef
-					break
-				}
+			ref, _ := g.TryBindOid(*valueOid)
+			return ref
+		}
+		kinds := guessKindFromKey(key)
+		for _, kind := range kinds {
+			maybeRef, didBind := g.TryBindId(kind, value)
+			if didBind {
+				return maybeRef
 			}
 		}
+		return value
 	})
 }
 
@@ -262,7 +265,7 @@ func (g *Generator) GetBindings() (BindingsObject, error) {
 			TfName:            workspaceTarget.TfName,
 			IsOid:             true,
 		},
-		WorkspaceName: g.cache.workspaceEntry.Label,
+		WorkspaceName: g.cache.workspaceEntry.LookupKey,
 	}, nil
 }
 
@@ -342,7 +345,7 @@ func guessKindFromKey(key string) []Kind {
 	}
 }
 
-func mapOverJsonStringKeys(data interface{}, f func(key string, value string, jsonMapNode map[string]interface{})) {
+func mapOverJsonStringKeys(data interface{}, f func(key string, value string) string) {
 	var stack []interface{}
 	stack = append(stack, data)
 	for len(stack) > 0 {
@@ -353,7 +356,7 @@ func mapOverJsonStringKeys(data interface{}, f func(key string, value string, js
 			for k, v := range jsonNode {
 				switch kvValue := v.(type) {
 				case string:
-					f(k, kvValue, jsonNode)
+					jsonNode[k] = f(k, kvValue)
 				// if value looks like a composite type, push onto stack for further
 				// processing
 				case map[string]interface{}:
@@ -363,8 +366,15 @@ func mapOverJsonStringKeys(data interface{}, f func(key string, value string, js
 				}
 			}
 		case []interface{}:
-			for _, object := range jsonNode {
-				stack = append(stack, object)
+			for i, v := range jsonNode {
+				switch val := v.(type) {
+				case string:
+					jsonNode[i] = f("", val)
+				case map[string]interface{}:
+					stack = append(stack, val)
+				case []interface{}:
+					stack = append(stack, val)
+				}
 			}
 		}
 	}

--- a/client/binding/binding_test.go
+++ b/client/binding/binding_test.go
@@ -58,11 +58,11 @@ func prepareResourceCacheFixture() ResourceCache {
 	}
 	disambiguator := 1
 	existingResourceNames := make(map[string]struct{})
-	r.addEntry(KindDataset, "dataset_1", dataset1Id, true, &disambiguator, existingResourceNames)
-	r.addEntry(KindDataset, "dataset_2", "41000200", true, &disambiguator, existingResourceNames)
-	r.addEntry(KindWorkspace, "Test wks", workspaceId, false, &disambiguator, existingResourceNames)
-	r.addEntry(KindWorksheet, "worksheet_1", "41000201", true, &disambiguator, existingResourceNames)
-	r.addEntry(KindUser, "basic_user", "41000100", true, &disambiguator, existingResourceNames)
+	r.addEntry(KindDataset, "dataset_1", "dataset_1", dataset1Id, true, &disambiguator, existingResourceNames)
+	r.addEntry(KindDataset, "dataset_2", "dataset_2", "41000200", true, &disambiguator, existingResourceNames)
+	r.addEntry(KindWorkspace, "Test wks", "Test wks", workspaceId, false, &disambiguator, existingResourceNames)
+	r.addEntry(KindWorksheet, "worksheet_1", "worksheet_1", "41000201", true, &disambiguator, existingResourceNames)
+	r.addEntry(KindUser, "basic@example.com", "basic_user", "41000100", true, &disambiguator, existingResourceNames)
 	r.workspaceEntry = r.LookupId(KindWorkspace, workspaceId)
 	return r
 }
@@ -123,6 +123,69 @@ func TestGenerateJson(t *testing.T) {
 	}
 	if !reflect.DeepEqual(output, expected) {
 		t.Fatalf("expected %#v, got %#v", expected, output)
+	}
+}
+
+func TestGenerateWithArrays(t *testing.T) {
+	g := prepareGeneratorFixture()
+
+	// scalars inside an array should be walked and replaced with local refs
+	input := map[string]interface{}{
+		"users": []interface{}{
+			// full OID for a user — should be bound via TryBindOid
+			"o:::user:41000100",
+		},
+	}
+	g.Generate(input)
+	users, ok := input["users"].([]interface{})
+	if !ok || len(users) != 1 {
+		t.Fatalf("expected users to remain a slice of length 1, got %#v", input["users"])
+	}
+	expectedRef := "${local.binding__type_name__user_basic_user}"
+	if users[0] != expectedRef {
+		t.Fatalf("expected %s, got %s", expectedRef, users[0])
+	}
+
+	// arrays of maps should also be walked recursively
+	g2 := prepareGeneratorFixture()
+	input2 := map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{
+				"datasetId": dataset1Id,
+			},
+		},
+	}
+	g2.Generate(input2)
+	items, ok := input2["items"].([]interface{})
+	if !ok || len(items) != 1 {
+		t.Fatalf("expected items slice length 1, got %#v", input2["items"])
+	}
+	item, ok := items[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected items[0] to be a map, got %T", items[0])
+	}
+	expectedDatasetRef := "${local.binding__type_name__dataset_dataset_1}"
+	if item["datasetId"] != expectedDatasetRef {
+		t.Fatalf("expected %s, got %s", expectedDatasetRef, item["datasetId"])
+	}
+
+	// nested arrays of scalars (array of array of OID strings)
+	g3 := prepareGeneratorFixture()
+	inner := []interface{}{"o:::user:41000100"}
+	input3 := map[string]interface{}{
+		"nested": []interface{}{inner},
+	}
+	g3.Generate(input3)
+	outerSlice, ok := input3["nested"].([]interface{})
+	if !ok || len(outerSlice) != 1 {
+		t.Fatalf("expected nested slice length 1, got %#v", input3["nested"])
+	}
+	innerSlice, ok := outerSlice[0].([]interface{})
+	if !ok || len(innerSlice) != 1 {
+		t.Fatalf("expected inner slice length 1, got %#v", outerSlice[0])
+	}
+	if innerSlice[0] != expectedRef {
+		t.Fatalf("expected %s, got %s", expectedRef, innerSlice[0])
 	}
 }
 

--- a/docs/data-sources/monitor_v2_action.md
+++ b/docs/data-sources/monitor_v2_action.md
@@ -45,6 +45,7 @@ one workspace, the server automatically assigns the correct workspace.
 
 ### Read-Only
 
+- `_bindings` (String) Internal field. Do not use.
 - `description` (String) description for this monitor v2 action.
 - `destination` (String)
 - `email` (Block List) Configuration settings for email type actions. (see [below for nested schema](#nestedblock--email))

--- a/observe/data_source_monitor_v2_action.go
+++ b/observe/data_source_monitor_v2_action.go
@@ -2,10 +2,12 @@ package observe
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	observe "github.com/observeinc/terraform-provider-observe/client"
+	"github.com/observeinc/terraform-provider-observe/client/binding"
 	gql "github.com/observeinc/terraform-provider-observe/client/meta"
 	"github.com/observeinc/terraform-provider-observe/client/oid"
 	"github.com/observeinc/terraform-provider-observe/observe/descriptions"
@@ -74,6 +76,11 @@ func dataSourceMonitorV2Action() *schema.Resource {
 			"destination": { // ObjectId!
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"_bindings": { // internal, used for generating bindings for cross-tenant export
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions.Get("monitor_v2_action", "schema", "_bindings"),
 			},
 		},
 	}
@@ -187,5 +194,44 @@ func dataSourceMonitorV2ActionRead(ctx context.Context, data *schema.ResourceDat
 	}
 
 	data.SetId(act.Id)
-	return resourceMonitorV2ActionRead(ctx, data, meta)
+	diags = resourceMonitorV2ActionRead(ctx, data, meta)
+	if diags.HasError() {
+		return diags
+	}
+
+	if client.ExportObjectBindings {
+		if err := generateMonitorV2ActionBindings(ctx, act, data, client); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return diags
+}
+
+// generateMonitorV2ActionBindings generates bindings for use in cross-tenant exports. See binding.go for details.
+func generateMonitorV2ActionBindings(ctx context.Context, act *gql.MonitorV2Action, data *schema.ResourceData, client *observe.Client) error {
+	bindFor := binding.NewKindSet(binding.KindWorkspace, binding.KindUser)
+	gen, err := binding.NewGenerator(ctx, binding.KindMonitorV2Action, act.Name, client, bindFor)
+	if err != nil {
+		return fmt.Errorf("failed to initialize binding generator: %w", err)
+	}
+
+	workspaceRef, _ := gen.TryBindOid(oid.WorkspaceOid(act.WorkspaceId))
+	if err := data.Set("workspace", workspaceRef); err != nil {
+		return err
+	}
+
+	// walk the email field to replace user OIDs with local variable references
+	if emailVal := data.Get("email"); emailVal != nil {
+		gen.Generate(emailVal)
+		if err := data.Set("email", emailVal); err != nil {
+			return err
+		}
+	}
+
+	bindingsJson, err := gen.GetBindingsJson()
+	if err != nil {
+		return err
+	}
+	return data.Set("_bindings", string(bindingsJson))
 }

--- a/observe/data_source_monitor_v2_action_test.go
+++ b/observe/data_source_monitor_v2_action_test.go
@@ -1,11 +1,15 @@
 package observe
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/observeinc/terraform-provider-observe/client/binding"
 )
 
 func TestAccObserveMonitorV2ActionEmailDatasource(t *testing.T) {
@@ -100,6 +104,113 @@ func TestAccObserveMonitorV2ActionWebhookDatasource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.observe_monitor_v2_action.act", "webhook.0.body", "never gonna run around and desert you"),
 					resource.TestCheckResourceAttr("data.observe_monitor_v2_action.act", "webhook.0.url", "https://example.com/"),
 					resource.TestCheckResourceAttr("data.observe_monitor_v2_action.act", "webhook.0.method", "post"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObserveMonitorV2ActionExportWithBindings(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+
+	providerPreamble := `
+		terraform {} # trick the testing framework into not mangling our config
+		provider "observe" {
+			export_object_bindings = true
+		}
+	`
+
+	workspaceTfName := fmt.Sprintf("workspace_%s", strings.ToLower(defaultWorkspaceName))
+	workspaceTfLocalBindingVar := fmt.Sprintf("binding__monitor_v2_action_%s__%s", randomPrefix, workspaceTfName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// email action with a user OID — expect workspace + user bindings
+				Config: fmt.Sprintf(providerPreamble+monitorV2ConfigPreamble+`
+					data "observe_user" "system" {
+						email = "%[2]s"
+					}
+
+					resource "observe_monitor_v2_action" "act" {
+						workspace = data.observe_workspace.default.oid
+						type = "email"
+						email {
+							subject = "export bindings test"
+							body    = "body"
+							users   = [data.observe_user.system.oid]
+						}
+						name = "%[1]s"
+					}
+
+					data "observe_monitor_v2_action" "act" {
+						id = observe_monitor_v2_action.act.id
+					}
+				`, randomPrefix, systemUser()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.observe_monitor_v2_action.act", "workspace", fmt.Sprintf("${local.%s}", workspaceTfLocalBindingVar)),
+					resource.TestCheckResourceAttrWith("data.observe_monitor_v2_action.act", "_bindings", func(value string) error {
+						var bindings binding.BindingsObject
+						if err := json.Unmarshal([]byte(value), &bindings); err != nil {
+							return err
+						}
+						expectedKinds := []binding.Kind{binding.KindUser, binding.KindWorkspace}
+						if !reflect.DeepEqual(bindings.Kinds, expectedKinds) {
+							return fmt.Errorf("bindings.Kinds does not match: expected %#v, got %#v", expectedKinds, bindings.Kinds)
+						}
+						expectedWorkspaceBinding := binding.Target{TfLocalBindingVar: workspaceTfLocalBindingVar, TfName: workspaceTfName, IsOid: true}
+						if bindings.Workspace != expectedWorkspaceBinding {
+							return fmt.Errorf("bindings.Workspace does not match: expected %#v, got %#v", expectedWorkspaceBinding, bindings.Workspace)
+						}
+						// user binding keyed by email
+						userRef := binding.Ref{Kind: binding.KindUser, Key: systemUser()}
+						if _, ok := bindings.Mappings[userRef]; !ok {
+							return fmt.Errorf("expected user binding with key %q, got mappings: %#v", systemUser(), bindings.Mappings)
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				// webhook action — only workspace binding, no user OIDs
+				Config: fmt.Sprintf(providerPreamble+monitorV2ConfigPreamble+`
+					resource "observe_monitor_v2_action" "act" {
+						workspace = data.observe_workspace.default.oid
+						type = "webhook"
+						webhook {
+							url    = "https://example.com/"
+							method = "post"
+							body   = "test"
+						}
+						name = "%[1]s_wh"
+					}
+
+					data "observe_monitor_v2_action" "act" {
+						id = observe_monitor_v2_action.act.id
+					}
+				`, randomPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.observe_monitor_v2_action.act", "workspace",
+						fmt.Sprintf("${local.binding__monitor_v2_action_%s_wh__%s}", randomPrefix, workspaceTfName)),
+					resource.TestCheckResourceAttrWith("data.observe_monitor_v2_action.act", "_bindings", func(value string) error {
+						var bindings binding.BindingsObject
+						if err := json.Unmarshal([]byte(value), &bindings); err != nil {
+							return err
+						}
+						expectedKinds := []binding.Kind{binding.KindUser, binding.KindWorkspace}
+						if !reflect.DeepEqual(bindings.Kinds, expectedKinds) {
+							return fmt.Errorf("bindings.Kinds does not match: expected %#v, got %#v", expectedKinds, bindings.Kinds)
+						}
+						// no user OIDs in webhook action, so Mappings should only have workspace
+						for ref := range bindings.Mappings {
+							if ref.Kind == binding.KindUser {
+								return fmt.Errorf("unexpected user binding in webhook action: %#v", ref)
+							}
+						}
+						return nil
+					}),
 				),
 			},
 		},

--- a/observe/descriptions/monitor_v2_action.yaml
+++ b/observe/descriptions/monitor_v2_action.yaml
@@ -9,3 +9,5 @@ schema:
     Configuration settings for webhook type actions.
   description: >
     description for this monitor v2 action.
+  _bindings: >
+    Internal field. Do not use.


### PR DESCRIPTION
## Summary

Adds `_bindings` to the `observe_monitor_v2_action` data source, enabling cross-tenant Terraform export. When `export_object_bindings = true`, the data source replaces raw OIDs with `${local.binding__…}` references and stashes the resolver manifest in `_bindings`.

## Changes

**`client/binding/binding.go`**

- **`mapOverJsonStringKeys` bug fix**: strings inside `[]interface{}` slices were silently dropped (no matching case on pop). Array elements are now handled inline, and the callback signature changed to `f(key, value string) string` so the walker owns write-back for both map and slice positions.
- **Users are keyed by email, not display name**: `observe_user` is looked up by email, and the monorepo template emits `email = "<Ref.Key>"`, so `Ref.Key` must be the email address.

**`observe/data_source_monitor_v2_action.go`**

Added `_bindings` schema field and `generateMonitorV2ActionBindings`, modeled on the existing monitor v2 implementation. Binds `KindWorkspace` and `KindUser`; walks the `email` field to replace user OIDs.

## Testing

- `TestGenerateWithArrays`: unit test for the array scalar fix.
- `TestAccObserveMonitorV2ActionExportWithBindings`: acceptance test covering email actions (user + workspace bindings) and webhook actions (workspace only).