### PR TITLE
fix: drop ExpectNonEmptyPlan from TestAccObserveMonitorV2ServiceBindingsWildcard

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/observeinc/terraform-provider-observe/observe"
 )
 
-//go:generate env -u OBSERVE_CUSTOMER go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate
+//go:generate env -u OBSERVE_CUSTOMER go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name terraform-provider-observe
 // `env -u` unsets a variable.  This prevents the go generate command from inheriting it.
 // When set, `OBSERVE_CUSTOMER` defines the default for the `customer` provider attribute.
 // This makes this required field optional, since a default is set.

--- a/observe/resource_monitor_v2_test.go
+++ b/observe/resource_monitor_v2_test.go
@@ -1428,12 +1428,6 @@ func TestAccObserveMonitorV2ServiceBindingsWildcard(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: allWildcard,
-				// Creating a monitor for a new dataset updates the dataset's
-				// freshness configuration on first save, which bumps the version
-				// timestamp in its OID. The observe_correlation_tag resources
-				// store the full versioned OID, so they show a ForceNew diff on
-				// the next plan. Subsequent monitor updates are idempotent.
-				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_name.0.match_mode", "wildcard"),
 					resource.TestCheckResourceAttr("observe_monitor_v2.first", "service_bindings.0.service_name.0.value", ""),


### PR DESCRIPTION
The test was asserting that applying the all-wildcard config leaves a non-empty plan, based on an old behavior where creating a monitor bumped the dataset's OID and caused `observe_correlation_tag` resources to schedule a ForceNew. That no longer happens, so the test was failing because the post-apply plan is now empty.

Also adds `--provider-name terraform-provider-observe` to the `go:generate` directive in main.go so `make generate` produces correctly-named docs files regardless of the binary/worktree name used to run it.