### PR TITLE
Normalize OID references to unversioned when omit-dataset-oid-version flag is on

### DIFF
--- a/observe/data_source_monitor.go
+++ b/observe/data_source_monitor.go
@@ -398,7 +398,7 @@ func dataSourceMonitorRead(ctx context.Context, data *schema.ResourceData, meta 
 		return
 	}
 	data.SetId(m.Id)
-	diags = monitorToResourceData(data, m)
+	diags = monitorToResourceData(data, m, client.Flags[flagOmitDatasetOIDVersion])
 	if diags.HasError() {
 		return diags
 	}

--- a/observe/helpers.go
+++ b/observe/helpers.go
@@ -301,19 +301,12 @@ func convertFlags(s string) (map[string]bool, error) {
 
 // setDatasetOID writes a dataset oid into resource state.
 func setDatasetOID(data *schema.ResourceData, id *oid.OID, omitVersion bool) error {
-	// Default behavior: always write the current versioned oid.
-	if !omitVersion {
-		return data.Set("oid", id.String())
-	}
-	// omit-dataset-oid-version: If it's the first time we're writing this (new resource), then
-	// write a version-free oid. If there's already an existing oid, then leave it as is, freezing
-	// the version in place, keeping downstream inputs stable.
-	if data.Get("oid").(string) == "" {
+	if omitVersion {
 		id.Version = nil
-		return data.Set("oid", id.String())
 	}
-	return nil
+	return data.Set("oid", id.String())
 }
+
 
 // determine whether we expect a new dataset version
 func datasetRecomputeOID(d *schema.ResourceDiff) bool {

--- a/observe/resource_correlation_tag.go
+++ b/observe/resource_correlation_tag.go
@@ -127,6 +127,13 @@ func resourceCorrelationTagRead(ctx context.Context, data *schema.ResourceData, 
 		// Mark the correlation tag as deleted.
 		data.SetId("")
 	}
+
+	// Normalize dataset to unversioned OID so state matches config.
+	if client.Flags[flagOmitDatasetOIDVersion] {
+		if err := data.Set(correlationTagDatasetKey, oid.DatasetOid(cTagParams.Dataset).String()); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	}
 	return diags
 }
 

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -412,7 +412,7 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData, omitVersio
 	}
 
 	if d.Transform != nil && d.Transform.Current != nil && d.Transform.Current.Query != nil {
-		_, err := flattenAndSetQuery(data, d.Transform.Current.Query.Stages, d.Transform.Current.Query.OutputStage)
+		_, err := flattenAndSetQuery(data, d.Transform.Current.Query.Stages, d.Transform.Current.Query.OutputStage, omitVersion)
 		if err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		}
@@ -425,7 +425,7 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData, omitVersio
 	return diags
 }
 
-func flattenAndSetQuery(data *schema.ResourceData, gqlstages []gql.StageQuery, outputStage string) ([]string, error) {
+func flattenAndSetQuery(data *schema.ResourceData, gqlstages []gql.StageQuery, outputStage string, omitVersion bool) ([]string, error) {
 	if len(gqlstages) == 0 {
 		return make([]string, 0), nil
 	}
@@ -442,11 +442,13 @@ func flattenAndSetQuery(data *schema.ResourceData, gqlstages []gql.StageQuery, o
 			Id:   *input.Dataset,
 		}
 
-		// check for existing version timestamp we can maintain
-		if v, ok := data.GetOk(fmt.Sprintf("inputs.%s", name)); ok {
-			prv, err := oid.NewOID(v.(string))
-			if err == nil && id.Id == prv.Id {
-				id.Version = prv.Version
+		if !omitVersion {
+			// check for existing version timestamp we can maintain
+			if v, ok := data.GetOk(fmt.Sprintf("inputs.%s", name)); ok {
+				prv, err := oid.NewOID(v.(string))
+				if err == nil && id.Id == prv.Id {
+					id.Version = prv.Version
+				}
 			}
 		}
 		inputs[name] = id.String()

--- a/observe/resource_dataset_query_filter.go
+++ b/observe/resource_dataset_query_filter.go
@@ -160,7 +160,15 @@ func resourceDatasetQueryFilterRead(ctx context.Context, data *schema.ResourceDa
 		return diag.Errorf("failed to retrieve dataset query filter: %s", err.Error())
 	}
 
-	return datasetQueryFilterToResourceData(result, data)
+	diags = datasetQueryFilterToResourceData(result, data)
+
+	// Normalize dataset to unversioned OID so state matches config.
+	if client.Flags[flagOmitDatasetOIDVersion] {
+		if err := data.Set("dataset", oid.DatasetOid(datasetOid.Id).String()); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	}
+	return diags
 }
 
 func resourceDatasetQueryFilterUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -1566,6 +1566,11 @@ func TestAccObserveDatasetOmitOIDVersionNewResources(t *testing.T) {
 // path: datasets are created with the flag OFF (versioned oids in state), then
 // the flag is toggled ON. Toggling must be a no-op (no plan diff), and a
 // subsequent upstream edit must not cascade onto downstream dependents.
+//
+// Dataset B takes inputs from both resource A and a data source (the "System"
+// system dataset), which is the scenario that originally exposed the bug: data
+// source OIDs were always emitted without a version, causing a mismatch against
+// the versioned values preserved in B's state.
 func TestAccObserveDatasetOmitOIDVersionMigration(t *testing.T) {
 	randomPrefix := acctest.RandomWithPrefix("tf")
 
@@ -1582,6 +1587,14 @@ func TestAccObserveDatasetOmitOIDVersionMigration(t *testing.T) {
 
 	datasetChain := func(provider, aPipeline string) string {
 		return fmt.Sprintf(provider+configPreamble+datastreamConfigPreamble+`
+		data "observe_dataset" "system" {
+			name = "System"
+		}
+
+		data "observe_rbac_group" "everyone" {
+			name = "Everyone"
+		}
+
 		resource "observe_dataset" "a" {
 			workspace = data.observe_workspace.default.oid
 			name      = "%[1]s-A"
@@ -1606,10 +1619,46 @@ func TestAccObserveDatasetOmitOIDVersionMigration(t *testing.T) {
 					filter true
 				EOF
 			}
+		}
+
+		resource "observe_dataset" "c" {
+			workspace = data.observe_workspace.default.oid
+			name      = "%[1]s-C"
+
+			inputs = { "system" = data.observe_dataset.system.oid }
+
+			stage {
+				pipeline = <<-EOF
+					filter false
+				EOF
+			}
+		}
+
+		resource "observe_link" "a_to_system" {
+			workspace = data.observe_workspace.default.oid
+			source    = observe_dataset.a.oid
+			target    = data.observe_dataset.system.oid
+			fields    = ["BUNDLE_TIMESTAMP"]
+			label     = "%[1]s-link"
+		}
+
+		resource "observe_correlation_tag" "on_a" {
+			dataset = observe_dataset.a.oid
+			name    = "%[1]s-ctag"
+			column  = "EXTRA"
+		}
+
+		resource "observe_resource_grants" "on_system" {
+			oid = data.observe_dataset.system.oid
+
+			grant {
+				subject = data.observe_rbac_group.everyone.oid
+				role    = "dataset_viewer"
+			}
 		}`, randomPrefix, aPipeline)
 	}
 
-	var aOID, bOID string
+	var bOID string
 
 	// Serial: overriding provider config mutates the shared testAccProvider
 	// instance, and this test also changes that config between steps.
@@ -1622,31 +1671,35 @@ func TestAccObserveDatasetOmitOIDVersionMigration(t *testing.T) {
 				Config: datasetChain(providerOff, "make_col x:1"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("observe_dataset.a", "oid", oidVersionedRegex),
-					resource.TestCheckResourceAttrWith("observe_dataset.a", "oid", func(v string) error {
-						aOID = v
-						return nil
-					}),
+					// With the flag off, dataset OID references in other resources
+					// preserve the versioned value in state.
+					resource.TestMatchResourceAttr("observe_dataset.c", "inputs.system", oidVersionedRegex),
+					resource.TestMatchResourceAttr("observe_link.a_to_system", "source", oidVersionedRegex),
+					resource.TestMatchResourceAttr("observe_resource_grants.on_system", "oid", oidVersionedRegex),
 					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
 						bOID = v
 						return nil
 					}),
 				),
 			},
+			// Verify that toggling the flag is a pure no-op: normalization on Read
+			// must converge state to unversioned before plan comparison so that no
+			// resources are marked for update.
+			testAccPlanOnlyNoDriftStep(datasetChain(providerOn, "make_col x:1")),
 			{
-				// Toggle the flag on with no config change. The existing versioned
-				// oids are frozen in place, so this must be a pure no-op.
+				// Apply with the flag on. OIDs are now normalized to version-free
+				// in state; capture them for subsequent assertions.
 				Config: datasetChain(providerOn, "make_col x:1"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrWith("observe_dataset.a", "oid", func(v string) error {
-						if v != aOID {
-							return fmt.Errorf("upstream oid changed on flag toggle: was %q, now %q", aOID, v)
-						}
-						return nil
-					}),
+					resource.TestMatchResourceAttr("observe_dataset.a", "oid", oidVersionFreeRegex),
+					resource.TestMatchResourceAttr("observe_dataset.b", "oid", oidVersionFreeRegex),
+					// All OID references normalize to unversioned on flag toggle.
+					resource.TestMatchResourceAttr("data.observe_dataset.system", "oid", oidVersionFreeRegex),
+					resource.TestMatchResourceAttr("observe_dataset.c", "inputs.system", oidVersionFreeRegex),
+					resource.TestMatchResourceAttr("observe_link.a_to_system", "source", oidVersionFreeRegex),
+					resource.TestMatchResourceAttr("observe_resource_grants.on_system", "oid", oidVersionFreeRegex),
 					resource.TestCheckResourceAttrWith("observe_dataset.b", "oid", func(v string) error {
-						if v != bOID {
-							return fmt.Errorf("downstream oid changed on flag toggle: was %q, now %q", bOID, v)
-						}
+						bOID = v
 						return nil
 					}),
 				),

--- a/observe/resource_link.go
+++ b/observe/resource_link.go
@@ -169,8 +169,19 @@ func resourceLinkRead(ctx context.Context, data *schema.ResourceData, meta inter
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	// TODO: we may need to set source and target, but if we do we must pass
-	// through version info in OID
+	// Normalize source/target to unversioned OIDs so state matches config.
+	if client.Flags[flagOmitDatasetOIDVersion] {
+		if link.SourceDataset != nil && link.SourceDataset.DatasetId != nil {
+			if err := data.Set("source", oid.DatasetOid(*link.SourceDataset.DatasetId).String()); err != nil {
+				diags = append(diags, diag.FromErr(err)...)
+			}
+		}
+		if link.TargetDataset != nil && link.TargetDataset.DatasetId != nil {
+			if err := data.Set("target", oid.DatasetOid(*link.TargetDataset.DatasetId).String()); err != nil {
+				diags = append(diags, diag.FromErr(err)...)
+			}
+		}
+	}
 
 	if err := data.Set("fields", fields); err != nil {
 		diags = append(diags, diag.FromErr(err)...)

--- a/observe/resource_log_derived_metric_dataset.go
+++ b/observe/resource_log_derived_metric_dataset.go
@@ -388,8 +388,10 @@ func logDerivedMetricDatasetToResourceData(d *gql.LogDerivedMetricDataset, data 
 	for _, in := range sq.Input {
 		if in.DatasetId != nil && *in.DatasetId != "" {
 			inputOID := oid.OID{Type: oid.TypeDataset, Id: *in.DatasetId}
-			if version := previousLDMInputOIDVersion(data, inputOID.Id); version != nil {
-				inputOID.Version = version
+			if !omitVersion {
+				if version := previousLDMInputOIDVersion(data, inputOID.Id); version != nil {
+					inputOID.Version = version
+				}
 			}
 			if err := data.Set("input", inputOID.String()); err != nil {
 				diags = append(diags, diag.FromErr(err)...)

--- a/observe/resource_monitor.go
+++ b/observe/resource_monitor.go
@@ -815,10 +815,10 @@ func resourceMonitorRead(ctx context.Context, data *schema.ResourceData, meta in
 		return diag.Errorf("failed to read monitor: %s", err.Error())
 	}
 
-	return monitorToResourceData(data, monitor)
+	return monitorToResourceData(data, monitor, client.Flags[flagOmitDatasetOIDVersion])
 }
 
-func monitorToResourceData(data *schema.ResourceData, monitor *gql.Monitor) (diags diag.Diagnostics) {
+func monitorToResourceData(data *schema.ResourceData, monitor *gql.Monitor, omitVersion bool) (diags diag.Diagnostics) {
 	if err := data.Set("workspace", oid.WorkspaceOid(monitor.WorkspaceId).String()); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
@@ -859,12 +859,12 @@ func monitorToResourceData(data *schema.ResourceData, monitor *gql.Monitor) (dia
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	stageIds, err := flattenAndSetQuery(data, monitor.Query.Stages, monitor.Query.OutputStage)
+	stageIds, err := flattenAndSetQuery(data, monitor.Query.Stages, monitor.Query.OutputStage, omitVersion)
 	if err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	if err := data.Set("rule", flattenRule(data, monitor.Rule, stageIds)); err != nil {
+	if err := data.Set("rule", flattenRule(data, monitor.Rule, stageIds, omitVersion)); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
@@ -881,7 +881,7 @@ func monitorToResourceData(data *schema.ResourceData, monitor *gql.Monitor) (dia
 	return diags
 }
 
-func flattenRule(data *schema.ResourceData, input gql.MonitorRule, stageIds []string) interface{} {
+func flattenRule(data *schema.ResourceData, input gql.MonitorRule, stageIds []string, omitVersion bool) interface{} {
 	rule := map[string]interface{}{
 		"source_column": input.GetSourceColumn(),
 	}
@@ -969,12 +969,14 @@ func flattenRule(data *schema.ResourceData, input gql.MonitorRule, stageIds []st
 
 		if logRule.SourceLogDatasetId != nil {
 			id := oid.DatasetOid(*logRule.SourceLogDatasetId)
-			// check for existing version timestamp we can maintain
-			// same approach as in flattenAndSetQuery() for input datasets
-			if v, ok := data.GetOk("rule.0.log.0.source_log_dataset"); ok {
-				prv, err := oid.NewOID(v.(string))
-				if err == nil && id.Id == prv.Id {
-					id.Version = prv.Version
+			if !omitVersion {
+				// check for existing version timestamp we can maintain
+				// same approach as in flattenAndSetQuery() for input datasets
+				if v, ok := data.GetOk("rule.0.log.0.source_log_dataset"); ok {
+					prv, err := oid.NewOID(v.(string))
+					if err == nil && id.Id == prv.Id {
+						id.Version = prv.Version
+					}
 				}
 			}
 			log["source_log_dataset"] = id.String()

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -956,7 +956,7 @@ func monitorV2ToResourceData(ctx context.Context, monitor *gql.MonitorV2, data *
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	_, err := flattenAndSetQuery(data, monitor.Definition.InputQuery.Stages, monitor.Definition.InputQuery.OutputStage)
+	_, err := flattenAndSetQuery(data, monitor.Definition.InputQuery.Stages, monitor.Definition.InputQuery.OutputStage, client.Flags[flagOmitDatasetOIDVersion])
 	if err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}

--- a/observe/resource_preferred_path.go
+++ b/observe/resource_preferred_path.go
@@ -232,6 +232,29 @@ func resourcePreferredPathRead(ctx context.Context, data *schema.ResourceData, m
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
+	// Normalize source/reverse_from to unversioned OIDs so state matches config.
+	if client.Flags[flagOmitDatasetOIDVersion] {
+		if err := data.Set("source", oid.DatasetOid(path.SourceDataset).String()); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+
+		steps := data.Get("step").([]interface{})
+		for i, apiStep := range path.Path {
+			if i >= len(steps) {
+				break
+			}
+			if apiStep.ReverseFromDataset == nil {
+				continue
+			}
+			step := steps[i].(map[string]interface{})
+			step["reverse_from"] = oid.DatasetOid(*apiStep.ReverseFromDataset).String()
+			steps[i] = step
+		}
+		if err := data.Set("step", steps); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	}
+
 	return diags
 }
 

--- a/observe/resource_resource_grants.go
+++ b/observe/resource_resource_grants.go
@@ -124,6 +124,12 @@ func resourceResourceGrantsRead(ctx context.Context, d *schema.ResourceData, m i
 		return diag.Errorf("failed to get grants: %s", err.Error())
 	}
 
+	// Normalize OID to unversioned so state matches config.
+	if client.Flags[flagOmitDatasetOIDVersion] {
+		resourceOid.Version = nil
+		d.SetId(resourceOid.String())
+	}
+
 	return grantsToResourceData(*resourceOid, grants, d)
 }
 


### PR DESCRIPTION
The previous 'freeze' approach in setDatasetOID relied on data.Get("oid") returning prior state to detect whether to preserve a versioned OID. This works for resources but not for data sources as the Terraform plugin SDK always rebuilds data sources from scratch on each read. Result: data sources always emitted unversioned OIDs when the flag is on, while consuming resources preserved versioned OIDs from their own prior state, producing phantom diffs on every plan.

Replace the freeze with consistent normalization: when the flag is on, strip versions everywhere on Read so state converges to unversioned and matches the config.

## What changed

When the flag is on, every resource that stores a dataset OID now normalizes it to unversioned during Read. This covers two categories:

**Resources whose Read already fetches the dataset ID from the API** (datasets, monitors, log-derived metrics, links, preferred paths, grants): the API returns bare dataset IDs without versions, so writing them back as unversioned OIDs is the natural behavior. The changes ensure that version-preservation logic (which previously copied the version from prior state back into the refreshed value) is skipped when the flag is on where relevant. For datasets and monitors this is in `flattenAndSetQuery`; for other resources it's in their respective Read functions.

**Resources whose Read does not fetch the dataset ID from the API** (correlation tags, dataset query filters, resource grants): the referenced dataset OID is treated as part of this resource's own identity and therefore stored only in state. When the flag is on, these now explicitly set the field to a reconstructed unversioned OID.

## Testing

Migration test now includes `data.observe_dataset.system` (data source), `observe_link`, `observe_correlation_tag`, and `observe_resource_grants` — all referencing a data source OID — with a plan-only-no-drift step verifying no phantom diffs after flag toggle.