### PR TITLE
fix(dashboard): populate description field from API response

### DIFF
--- a/client/internal/meta/operation/dashboard.graphql
+++ b/client/internal/meta/operation/dashboard.graphql
@@ -35,6 +35,7 @@ fragment valueFields on Value {
 fragment Dashboard on Dashboard {
     id
     name
+    description
     iconUrl
     workspaceId
     managedById

--- a/client/meta/genqlient.generated.go
+++ b/client/meta/genqlient.generated.go
@@ -962,6 +962,7 @@ const (
 type Dashboard struct {
 	Id              string                                     `json:"id"`
 	Name            string                                     `json:"name"`
+	Description     *string                                    `json:"description"`
 	IconUrl         *string                                    `json:"iconUrl"`
 	WorkspaceId     string                                     `json:"workspaceId"`
 	ManagedById     *string                                    `json:"managedById"`
@@ -978,6 +979,9 @@ func (v *Dashboard) GetId() string { return v.Id }
 
 // GetName returns Dashboard.Name, and is useful for accessing the field via an interface.
 func (v *Dashboard) GetName() string { return v.Name }
+
+// GetDescription returns Dashboard.Description, and is useful for accessing the field via an interface.
+func (v *Dashboard) GetDescription() *string { return v.Description }
 
 // GetIconUrl returns Dashboard.IconUrl, and is useful for accessing the field via an interface.
 func (v *Dashboard) GetIconUrl() *string { return v.IconUrl }
@@ -17501,6 +17505,7 @@ query getDashboard ($id: ObjectId!) {
 fragment Dashboard on Dashboard {
 	id
 	name
+	description
 	iconUrl
 	workspaceId
 	managedById
@@ -21015,6 +21020,7 @@ mutation saveDashboard ($dashboardInput: DashboardInput!) {
 fragment Dashboard on Dashboard {
 	id
 	name
+	description
 	iconUrl
 	workspaceId
 	managedById

--- a/observe/data_source_dashboard_test.go
+++ b/observe/data_source_dashboard_test.go
@@ -22,9 +22,10 @@ func TestAccObserveSourceDashboard(t *testing.T) {
 			{
 				Config: fmt.Sprintf(configPreamble+`
 					resource "observe_dashboard" "first" {
-						workspace = data.observe_workspace.default.oid
-						name      = "%s"
-						icon_url  = "test"
+						workspace   = data.observe_workspace.default.oid
+						name        = "%[1]s"
+						description = "%[1]s description"
+						icon_url    = "test"
 						stages = <<-EOF
 						[{
 							"pipeline": "filter field = \"cpu_usage_core_seconds\"\ncolmake cpu_used: value - lag(value, 1), groupby(clusterUid, namespace, podName, containerName)\ncolmake cpu_used: case(\n cpu_used < 0, value, // stream reset for cumulativeCounter metric\n true, cpu_used)\ncoldrop field, value",
@@ -38,12 +39,14 @@ func TestAccObserveSourceDashboard(t *testing.T) {
 					}
 
 					data "observe_dashboard" "lookup" {
-						id        = observe_dashboard.first.id
+						id = observe_dashboard.first.id
 					}
 				`, randomPrefix),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_dashboard.first", "description", randomPrefix+" description"),
 					resource.TestCheckResourceAttrSet("data.observe_dashboard.lookup", "workspace"),
 					resource.TestCheckResourceAttr("data.observe_dashboard.lookup", "name", randomPrefix),
+					resource.TestCheckResourceAttr("data.observe_dashboard.lookup", "description", randomPrefix+" description"),
 				),
 			},
 		},

--- a/observe/resource_dashboard.go
+++ b/observe/resource_dashboard.go
@@ -160,6 +160,12 @@ func dashboardToResourceData(d *gql.Dashboard, data *schema.ResourceData) (diags
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
+	if d.Description != nil {
+		if err := data.Set("description", *d.Description); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	}
+
 	if d.IconUrl != nil {
 		if err := data.Set("icon_url", *d.IconUrl); err != nil {
 			diags = append(diags, diag.FromErr(err)...)


### PR DESCRIPTION
`dashboardToResourceData` never called `data.Set` for the `description` field, so it was always empty.