### PR TITLE
Add import support for correlation tags

### DIFF
--- a/docs/resources/correlation_tag.md
+++ b/docs/resources/correlation_tag.md
@@ -52,4 +52,8 @@ Then the path to the key "c" would be "a.b.c" or "a['b']['c']"
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
+## Import
+Import is supported using the following syntax:
+```shell
+terraform import observe_correlation_tag.example '{"Dataset":"1414010","Tag":"service.name","Path":{"Column":"service"}}'
+```

--- a/examples/resources/observe_correlation_tag/import.sh
+++ b/examples/resources/observe_correlation_tag/import.sh
@@ -1,0 +1,1 @@
+terraform import observe_correlation_tag.example '{"Dataset":"1414010","Tag":"service.name","Path":{"Column":"service"}}'

--- a/observe/resource_correlation_tag.go
+++ b/observe/resource_correlation_tag.go
@@ -25,6 +25,9 @@ func resourceCorrelationTag() *schema.Resource {
 		CreateContext: resourceCorrelationTagCreate,
 		ReadContext:   resourceCorrelationTagRead,
 		DeleteContext: resourceCorrelationTagDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			correlationTagDatasetKey: {
 				Type:             schema.TypeString,
@@ -63,8 +66,15 @@ func newCorrelationTagConfig(data *schema.ResourceData) (params correlationTagPa
 	tag, _ := data.Get(correlationTagNameKey).(string)
 	column, _ := data.Get(correlationTagColumnKey).(string)
 	objectPath, _ := data.Get(correlationTagPathKey).(string)
+	// An empty path means "no path" and must stay nil rather than becoming a pointer to "":
+	// downstream lookups (IsCorrelationTagPresent) and the ID we construct for import compare
+	// this pointer for equality, and nil is the convention they use for "unset".
+	var pathPtr *string
+	if objectPath != "" {
+		pathPtr = &objectPath
+	}
 	path := gql.LinkFieldInput{
-		Path:   &objectPath,
+		Path:   pathPtr,
 		Column: column,
 	}
 	params = correlationTagParameters{
@@ -120,13 +130,27 @@ func resourceCorrelationTagRead(ctx context.Context, data *schema.ResourceData, 
 	if err != nil {
 		return diag.Errorf("failed to deconstruct correlation tag id: %s", err.Error())
 	}
+
 	isPresent, err := client.IsCorrelationTagPresent(ctx, cTagParams.Dataset, cTagParams.Tag, cTagParams.Path)
 	if err != nil {
-		diags = append(diags, diag.FromErr(err)...)
-	} else if !isPresent {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if !isPresent {
 		// Mark the correlation tag as deleted.
 		data.SetId("")
+		return diags
 	}
+
+	// The ID is the only source of truth for these fields (correlation tags have no backend
+	// id of their own), so populate them here. This makes Read self-sufficient, which is what
+	// lets plain ID-based import work via schema.ImportStatePassthroughContext.
+	data.Set(correlationTagDatasetKey, oid.DatasetOid(cTagParams.Dataset).String())
+	data.Set(correlationTagNameKey, cTagParams.Tag)
+	data.Set(correlationTagColumnKey, cTagParams.Path.Column)
+	if cTagParams.Path.Path != nil && *cTagParams.Path.Path != "" {
+		data.Set(correlationTagPathKey, *cTagParams.Path.Path)
+	}
+
 	return diags
 }
 

--- a/observe/resource_correlation_tag_test.go
+++ b/observe/resource_correlation_tag_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	gql "github.com/observeinc/terraform-provider-observe/client/meta"
+	"github.com/observeinc/terraform-provider-observe/client/oid"
 )
 
 func TestCorrelationTagCreation(t *testing.T) {
@@ -27,6 +30,30 @@ func TestCorrelationTagCreation(t *testing.T) {
 					resource.TestCheckResourceAttr("observe_correlation_tag.example", "column", "key"),
 					resource.TestCheckResourceAttrSet("observe_correlation_tag.example", "dataset"),
 				),
+			},
+			{
+				ResourceName: "observe_correlation_tag.example",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["observe_correlation_tag.example"]
+					if !ok {
+						return "", fmt.Errorf("resource not found in state")
+					}
+					// Reconstruct the JSON ID from resource attributes
+					datasetOid, _ := oid.NewOID(rs.Primary.Attributes["dataset"])
+					params := correlationTagParameters{
+						Dataset: datasetOid.Id,
+						Tag:     rs.Primary.Attributes["name"],
+						Path: gql.LinkFieldInput{
+							Column: rs.Primary.Attributes["column"],
+						},
+					}
+					if path, ok := rs.Primary.Attributes["path"]; ok && path != "" {
+						params.Path.Path = &path
+					}
+					return constructCorrelationTagId(params.Dataset, params.Tag, params.Path), nil
+				},
+				ImportStateVerify: true,
 			},
 			// Using the same config, there should not be any diff.
 			{


### PR DESCRIPTION
## Summary

Enables `terraform import` for `observe_correlation_tag`, so existing correlation tags can be brought under Terraform management without recreating them.

## Import ID format

Correlation tags have no backend-native ID — a tag is really just a `(dataset, name, column, path)` combination. The import ID is JSON-encoded rather than a delimited string (e.g. `dataset/name/column/path`) because tag keys can contain arbitrary special characters, including any character that could otherwise serve as a delimiter. JSON avoids that ambiguity without restricting what a tag key can contain.

## Implementation

`Read` decodes the ID into `(dataset, name, column, path)`, confirms the tag exists via `IsCorrelationTagPresent`, and sets those fields in state, making it the one place that turns an ID into full resource state for both a normal refresh and an import. Import itself is just `schema.ImportStatePassthroughContext`, which sets the ID and lets `Read` populate the rest.

A path-less tag's `path` is now left unset (`nil`) rather than encoded as an empty string, since tag lookups compare it for equality against the stored value — leaving it inconsistent meant a path-less tag's own ID couldn't find itself.

Example:

```
terraform import observe_correlation_tag.example '{"Dataset":"1414010","Tag":"service.name","Path":{"Column":"service"}}'
```