### PR TITLE
Adopt existing correlation tags instead of failing on create

### DIFF
--- a/docs/resources/correlation_tag.md
+++ b/docs/resources/correlation_tag.md
@@ -4,10 +4,19 @@ page_title: "observe_correlation_tag Resource - terraform-provider-observe"
 subcategory: ""
 description: |-
   A correlation tag can be attached to columns of a dataset. These tags are later used to correlate multiple datasets.
+  A correlation tag is uniquely identified by its (dataset, name, column, path)
+  combination rather than by a separate ID. If a correlation tag with the same
+  combination already exists -- for example, created previously through the UI --
+  this resource adopts it instead of failing.
 ---
 # observe_correlation_tag
 
 A correlation tag can be attached to columns of a dataset. These tags are later used to correlate multiple datasets.
+
+A correlation tag is uniquely identified by its (dataset, name, column, path)
+combination rather than by a separate ID. If a correlation tag with the same
+combination already exists -- for example, created previously through the UI --
+this resource adopts it instead of failing.
 ## Example Usage
 ```terraform
 data "observe_workspace" "default" {

--- a/observe/descriptions/correlation_tag.yaml
+++ b/observe/descriptions/correlation_tag.yaml
@@ -1,5 +1,10 @@
 description: |
   A correlation tag can be attached to columns of a dataset. These tags are later used to correlate multiple datasets.
+
+  A correlation tag is uniquely identified by its (dataset, name, column, path)
+  combination rather than by a separate ID. If a correlation tag with the same
+  combination already exists -- for example, created previously through the UI --
+  this resource adopts it instead of failing.
 schema:
   dataset: |
     OID of the dataset to which the correlation tag should be attached.

--- a/observe/resource_correlation_tag.go
+++ b/observe/resource_correlation_tag.go
@@ -101,13 +101,28 @@ func resourceCorrelationTagCreate(ctx context.Context, data *schema.ResourceData
 		return diags
 	}
 
-	err := client.CreateCorrelationTag(ctx, params.Dataset, params.Tag, params.Path)
+	// A correlation tag isn't a first-class object with its own identity -- it's
+	// just a (dataset, tag, column, path) combination, and that combination is
+	// its entire state. If it already exists (e.g. someone created it in the UI,
+	// or in another `apply`), there's nothing left to reconcile, so adopt it into
+	// this resource instead of failing.
+	isPresent, err := client.IsCorrelationTagPresent(ctx, params.Dataset, params.Tag, params.Path)
 	if err != nil {
 		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "failed to create correlation tag",
+			Summary:  "failed to check for existing correlation tag",
 			Detail:   err.Error(),
 		})
+	}
+
+	if !isPresent {
+		if err := client.CreateCorrelationTag(ctx, params.Dataset, params.Tag, params.Path); err != nil {
+			return append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "failed to create correlation tag",
+				Detail:   err.Error(),
+			})
+		}
 	}
 
 	data.SetId(constructCorrelationTagId(params.Dataset, params.Tag, params.Path))

--- a/observe/resource_correlation_tag_test.go
+++ b/observe/resource_correlation_tag_test.go
@@ -1,11 +1,15 @@
 package observe
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	observe "github.com/observeinc/terraform-provider-observe/client"
+	gql "github.com/observeinc/terraform-provider-observe/client/meta"
 )
 
 func TestCorrelationTagCreation(t *testing.T) {
@@ -18,10 +22,10 @@ func TestCorrelationTagCreation(t *testing.T) {
 			{
 				Config: fmt.Sprintf(linkConfigPreamble+`
 					resource "observe_correlation_tag" "example" {
-					name = "%[1]s-key.name"
-					dataset = observe_dataset.a.oid
-					column = "key"
-				}`, randomPrefix),
+						name = "%[1]s-key.name"
+						dataset = observe_dataset.a.oid
+						column = "key"
+					}`, randomPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("observe_correlation_tag.example", "name", fmt.Sprintf("%s-key.name", randomPrefix)),
 					resource.TestCheckResourceAttr("observe_correlation_tag.example", "column", "key"),
@@ -32,10 +36,10 @@ func TestCorrelationTagCreation(t *testing.T) {
 			{
 				Config: fmt.Sprintf(linkConfigPreamble+`
 					resource "observe_correlation_tag" "example" {
-					name = "%[1]s-key.name"
-					dataset = observe_dataset.a.oid
-					column = "key"
-				}`, randomPrefix),
+						name = "%[1]s-key.name"
+						dataset = observe_dataset.a.oid
+						column = "key"
+					}`, randomPrefix),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -43,12 +47,98 @@ func TestCorrelationTagCreation(t *testing.T) {
 				// Making any change to the config should delete and recreate the tag (in-place update is not supported)
 				Config: fmt.Sprintf(linkConfigPreamble+`
 					resource "observe_correlation_tag" "example" {
-					name = "%[1]s-key.name-2"
-					dataset = observe_dataset.a.oid
-					column = "key"
-				}`, randomPrefix),
+						name = "%[1]s-key.name-2"
+						dataset = observe_dataset.a.oid
+						column = "key"
+					}`, randomPrefix),
 				Check: resource.TestCheckResourceAttr("observe_correlation_tag.example", "name", fmt.Sprintf("%s-key.name-2", randomPrefix)),
 			},
+		},
+	})
+}
+
+// TestCorrelationTagAdoptExisting verifies that creating a correlation tag that
+// already exists on the dataset -- e.g. because it was created in the UI, or by
+// another `apply` -- adopts the existing tag instead of failing. A correlation tag
+// has no ID of its own; it's identified entirely by its (dataset, tag, column, path)
+// combination, so an existing match is already in the desired state.
+//
+// It also verifies that adoption is scoped exactly to that combination: a second
+// resource sharing the tag's (dataset, name) but pointing at a different column
+// (example_other_column, on OBSERVATION_KIND -- a default column on any
+// datastream-backed dataset) is not mistaken for the adopted tag on "key" and gets
+// created as its own independent mapping.
+func TestCorrelationTagAdoptExisting(t *testing.T) {
+	randomPrefix := acctest.RandomWithPrefix("tf")
+	tag := fmt.Sprintf("%s-key.name", randomPrefix)
+
+	var datasetID string
+
+	correlationTagConfig := fmt.Sprintf(linkConfigPreamble+`
+			resource "observe_correlation_tag" "example" {
+				name = "%[1]s-key.name"
+				dataset = observe_dataset.a.oid
+				column = "key"
+			}
+
+			resource "observe_correlation_tag" "example_other_column" {
+				name = "%[1]s-key.name"
+				dataset = observe_dataset.a.oid
+				column = "OBSERVATION_KIND"
+			}`, randomPrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Get the dataset created (and the provider configured) without
+				// declaring the correlation tag resource yet, so the next step's
+				// PreConfig can create the tag out-of-band -- simulating a tag
+				// that was already created outside of this Terraform config.
+				Config: fmt.Sprintf(linkConfigPreamble, randomPrefix),
+				Check: func(s *terraform.State) error {
+					rs, ok := s.RootModule().Resources["observe_dataset.a"]
+					if !ok {
+						return fmt.Errorf("observe_dataset.a not found in state")
+					}
+					datasetID = rs.Primary.ID
+					return nil
+				},
+			},
+			{
+				PreConfig: func() {
+					client := testAccProvider.Meta().(*observe.Client)
+					if err := client.CreateCorrelationTag(context.Background(), datasetID, tag, gql.LinkFieldInput{
+						Column: "key",
+						Path:   stringPtr(""),
+					}); err != nil {
+						t.Fatalf("failed to pre-create correlation tag out-of-band: %s", err)
+					}
+				},
+				Config: correlationTagConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("observe_correlation_tag.example", "name", tag),
+					resource.TestCheckResourceAttr("observe_correlation_tag.example", "column", "key"),
+					resource.TestCheckResourceAttrSet("observe_correlation_tag.example", "dataset"),
+					// example_other_column shares example's (dataset, name) but tags a
+					// different column, so it should be created as its own distinct
+					// mapping rather than being adopted into "example".
+					resource.TestCheckResourceAttr("observe_correlation_tag.example_other_column", "name", tag),
+					resource.TestCheckResourceAttr("observe_correlation_tag.example_other_column", "column", "OBSERVATION_KIND"),
+					func(s *terraform.State) error {
+						example := s.RootModule().Resources["observe_correlation_tag.example"]
+						otherColumn := s.RootModule().Resources["observe_correlation_tag.example_other_column"]
+						if example.Primary.ID == otherColumn.Primary.ID {
+							return fmt.Errorf("expected distinct correlation tags for different columns sharing a tag name, got identical ID %q", example.Primary.ID)
+						}
+						return nil
+					},
+				),
+			},
+			// Adopting the existing tag, and creating the distinct one on a
+			// different column, should leave no further diff.
+			testAccPlanOnlyNoDriftStep(correlationTagConfig),
 		},
 	})
 }


### PR DESCRIPTION
## Summary

A correlation tag has no ID of its own -- it's identified entirely by its `(dataset, tag, column, path)` combination, not just by dataset and name: the same tag name can be attached to multiple columns (or paths) on the same dataset, each a distinct mapping. A matching tag that already exists under that full combination is already in the desired state. `observe_correlation_tag` create now checks whether that exact combination already exists and, if so, adopts it (a no-op) instead of failing -- for example when it was previously created through the UI, or by another `apply`.

## Testing

Added `TestCorrelationTagAdoptExisting`, which creates the tag out-of-band via the API client before applying the `observe_correlation_tag` resource, and asserts the apply succeeds with no error and no subsequent plan diff. It also applies a second resource sharing the same `(dataset, name)` but a different column, and asserts it's created as its own distinct mapping rather than being adopted into the first.

Tags created by system content packages aren't special-cased here -- the backend doesn't expose tag creator info over GraphQL today, so adopting one behaves like adopting any other tag. If it's later destroyed, the backend's existing restriction on deleting system-created tags still applies unchanged.