### PR TITLE
fix(query): stop perpetual plan diff from inputs no stage uses

### DIFF
--- a/observe/data_source_query.go
+++ b/observe/data_source_query.go
@@ -491,6 +491,24 @@ func dataSourceQueryRead(ctx context.Context, data *schema.ResourceData, meta in
 // 	return diags
 // }
 
+// inputIsUsed reports whether any stage uses inputName, either by naming it as
+// that stage's explicit input or by referencing @inputName in its pipeline.
+//
+// This is what the write path attaches to a stage, so an input no stage uses is
+// dropped on save: it goes into no stage, and MultiStageQueryInput has no
+// top-level input list to carry it. See appendReferencedInputs.
+func inputIsUsed(stages []*Stage, inputName string) bool {
+	for _, stage := range stages {
+		if stage.Input != nil && *stage.Input == inputName {
+			return true
+		}
+		if pipelineReferencesInput(stage.Pipeline, inputName) {
+			return true
+		}
+	}
+	return false
+}
+
 func flattenQuery(gqlStages []gql.StageQuery, outputStage string) (*Query, error) {
 	query := &Query{Inputs: make(map[string]*Input)}
 

--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -412,10 +412,8 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData) (diags dia
 	}
 
 	if d.Transform != nil && d.Transform.Current != nil && d.Transform.Current.Query != nil {
-		_, err := flattenAndSetQuery(data, d.Transform.Current.Query.Stages, d.Transform.Current.Query.OutputStage)
-		if err != nil {
-			diags = append(diags, diag.FromErr(err)...)
-		}
+		_, queryDiags := flattenAndSetQuery(data, d.Transform.Current.Query.Stages, d.Transform.Current.Query.OutputStage)
+		diags = append(diags, queryDiags...)
 	}
 
 	if err := data.Set("oid", d.Oid().String()); err != nil {
@@ -425,14 +423,16 @@ func datasetToResourceData(d *gql.Dataset, data *schema.ResourceData) (diags dia
 	return diags
 }
 
-func flattenAndSetQuery(data *schema.ResourceData, gqlstages []gql.StageQuery, outputStage string) ([]string, error) {
+func flattenAndSetQuery(data *schema.ResourceData, gqlstages []gql.StageQuery, outputStage string) ([]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
 	if len(gqlstages) == 0 {
 		return make([]string, 0), nil
 	}
 
 	queryData, err := flattenQuery(gqlstages, outputStage)
 	if err != nil {
-		return nil, err
+		return nil, diag.FromErr(err)
 	}
 
 	inputs := make(map[string]interface{}, 0)
@@ -452,8 +452,32 @@ func flattenAndSetQuery(data *schema.ResourceData, gqlstages []gql.StageQuery, o
 		inputs[name] = id.String()
 	}
 
+	// Carry forward only the inputs the write path is known to drop: the ones no stage
+	// uses. Those never reach the API, so without this every plan would show them as a
+	// fresh addition that applying never resolves. Warn too, since the declaration has
+	// no effect.
+	//
+	// Anything else missing from the response was changed outside Terraform, so it stays
+	// out of state and surfaces as a diff for the next apply to restore.
+	for name, prior := range data.Get("inputs").(map[string]interface{}) {
+		if _, ok := inputs[name]; ok {
+			continue
+		}
+		if inputIsUsed(queryData.Stages, name) {
+			continue
+		}
+
+		inputs[name] = prior
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("input %q is not used by any stage", name),
+			Detail: "Observe does not save inputs that no stage references, so this one is not stored. " +
+				"Remove it from inputs, or reference it from a stage pipeline as @" + name + ".",
+		})
+	}
+
 	if err := data.Set("inputs", inputs); err != nil {
-		return nil, err
+		return nil, diag.FromErr(err)
 	}
 
 	stages := make([]interface{}, len(queryData.Stages))
@@ -474,10 +498,10 @@ func flattenAndSetQuery(data *schema.ResourceData, gqlstages []gql.StageQuery, o
 	}
 
 	if err := data.Set("stage", stages); err != nil {
-		return nil, err
+		return nil, append(diags, diag.FromErr(err)...)
 	}
 
-	return queryData.StageIds, nil
+	return queryData.StageIds, diags
 }
 
 func resourceDatasetCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {

--- a/observe/resource_dataset_test.go
+++ b/observe/resource_dataset_test.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	gql "github.com/observeinc/terraform-provider-observe/client/meta"
+	"github.com/observeinc/terraform-provider-observe/client/oid"
 )
 
 func TestAccObserveDatasetNameValidationTooLong(t *testing.T) {
@@ -1460,5 +1463,75 @@ func TestAccObserveDatasetNoWorkspace(t *testing.T) {
 					stage {}
 				}`, randomPrefix)),
 		},
+	})
+}
+
+// TestFlattenAndSetQueryUnusedInputs covers which declared inputs are carried forward when the
+// backend response omits them. An input no stage uses is dropped on save, so carrying it forward
+// is what stops it reappearing as a planned addition on every plan; anything else missing was
+// changed outside Terraform and must still surface as a diff.
+func TestFlattenAndSetQueryUnusedInputs(t *testing.T) {
+	const (
+		primaryID = "11111"
+		secondID  = "22222"
+	)
+	stageID := "stage-0"
+
+	// Simulates the backend response: only the default input is stored, whatever the config
+	// declared, because an input no stage uses is never attached to a stage on write.
+	buildStages := func(pipeline string) []gql.StageQuery {
+		return []gql.StageQuery{{
+			Id:       stringPtr(stageID),
+			Pipeline: pipeline,
+			Input: []gql.StageQueryInputInputDefinition{
+				{InputName: "primary", InputRole: gql.InputRoleData, DatasetId: stringPtr(primaryID)},
+			},
+		}}
+	}
+
+	buildData := func(pipeline, secondInput string) *schema.ResourceData {
+		return schema.TestResourceDataRaw(t, resourceDataset().Schema, map[string]interface{}{
+			"name": "test",
+			"inputs": map[string]interface{}{
+				"primary":   oid.OID{Type: oid.TypeDataset, Id: primaryID}.String(),
+				secondInput: oid.OID{Type: oid.TypeDataset, Id: secondID}.String(),
+			},
+			"stage": []interface{}{map[string]interface{}{"pipeline": pipeline, "alias": "", "input": "primary", "output_stage": false}},
+		})
+	}
+
+	t.Run("input that no stage uses is kept in state", func(t *testing.T) {
+		// "orphan" is declared but never used, so the write path drops it and the backend
+		// has no record of it. Carrying it forward is what keeps the plan clean.
+		const pipeline = "filter true"
+		data := buildData(pipeline, "orphan")
+		if _, diags := flattenAndSetQuery(data, buildStages(pipeline), stageID); diags.HasError() {
+			t.Fatalf("flattenAndSetQuery: %v", diags)
+		}
+		inputs := data.Get("inputs").(map[string]interface{})
+		if _, ok := inputs["orphan"]; !ok {
+			t.Errorf("unused input should be kept in state, got %v", inputs)
+		}
+		if len(inputs) != 2 {
+			t.Errorf("expected exactly 2 inputs in state, got %d: %v", len(inputs), inputs)
+		}
+	})
+
+	t.Run("used input removed outside terraform is still surfaced as a diff", func(t *testing.T) {
+		// A stage references @joined, so this is not an input the write path drops. Its
+		// absence from the response means something removed it outside Terraform, which
+		// must stay out of state so the plan shows it and the next apply restores it.
+		const pipeline = `join @joined`
+		data := buildData(pipeline, "joined")
+		if _, diags := flattenAndSetQuery(data, buildStages(pipeline), stageID); diags.HasError() {
+			t.Fatalf("flattenAndSetQuery: %v", diags)
+		}
+		inputs := data.Get("inputs").(map[string]interface{})
+		if _, ok := inputs["joined"]; ok {
+			t.Errorf("used input missing from the response should not be carried forward, got %v", inputs)
+		}
+		if len(inputs) != 1 {
+			t.Errorf("expected exactly 1 input in state, got %d: %v", len(inputs), inputs)
+		}
 	})
 }

--- a/observe/resource_monitor.go
+++ b/observe/resource_monitor.go
@@ -859,10 +859,8 @@ func monitorToResourceData(data *schema.ResourceData, monitor *gql.Monitor) (dia
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	stageIds, err := flattenAndSetQuery(data, monitor.Query.Stages, monitor.Query.OutputStage)
-	if err != nil {
-		diags = append(diags, diag.FromErr(err)...)
-	}
+	stageIds, queryDiags := flattenAndSetQuery(data, monitor.Query.Stages, monitor.Query.OutputStage)
+	diags = append(diags, queryDiags...)
 
 	if err := data.Set("rule", flattenRule(data, monitor.Rule, stageIds)); err != nil {
 		diags = append(diags, diag.FromErr(err)...)

--- a/observe/resource_monitor_v2.go
+++ b/observe/resource_monitor_v2.go
@@ -956,10 +956,8 @@ func monitorV2ToResourceData(ctx context.Context, monitor *gql.MonitorV2, data *
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	_, err := flattenAndSetQuery(data, monitor.Definition.InputQuery.Stages, monitor.Definition.InputQuery.OutputStage)
-	if err != nil {
-		diags = append(diags, diag.FromErr(err)...)
-	}
+	_, queryDiags := flattenAndSetQuery(data, monitor.Definition.InputQuery.Stages, monitor.Definition.InputQuery.OutputStage)
+	diags = append(diags, queryDiags...)
 
 	if monitor.Definition.RuleTemplate != nil && monitor.Definition.RuleTemplate.Anomaly != nil {
 		if err := data.Set("rule_template", monitorV2FlattenRuleTemplate(*monitor.Definition.RuleTemplate)); err != nil {


### PR DESCRIPTION
## Problem

An input declared in `inputs` that no stage uses — neither named as a stage's `input` nor referenced as `@name` in a pipeline — is dropped when the query is written. `appendReferencedInputs` attaches inputs to individual stages and `MultiStageQueryInput` has no top-level input list, so the input never reaches the API. It is then absent from the read while the configuration still declares it, so every plan shows it as a pending addition that applying never resolves.

Affects `observe_dataset`, `observe_monitor`, and `observe_monitor_v2`, which share `flattenAndSetQuery`.

## Fix

`flattenAndSetQuery` carries such an input forward from the prior value rather than letting it fall out of state, and warns that the declaration has no effect. It now returns `diag.Diagnostics` so the warning reaches the caller.

Two cases are deliberately left alone. Distinguishing either one requires the API response, which is why this lives on the read path rather than in a plan-time or write-path check:

- An input a stage does reference but that is missing from the response is a real discrepancy, so it is not carried forward and still surfaces as a diff.
- An input the API does return is never warned about. This covers inputs Observe derives from `^`"link"` traversals; `inputIsUsed` does not count a traversal as a use, since the traversal names the link rather than the input.

Existing state converges after one apply. The first plan still shows the addition, applying is a no-op against Observe, and the read that follows carries the input forward.

## Testing

`TestFlattenAndSetQueryUnusedInputs` in `observe/resource_dataset_test.go` covers the carry-forward for inputs no stage uses, and verifies that a used input removed outside Terraform still surfaces as a diff.