### PR TITLE
fix perpetual diff when stage input names the preceding stage's alias

### DIFF
--- a/observe/resource_dataset.go
+++ b/observe/resource_dataset.go
@@ -467,8 +467,8 @@ func flattenAndSetQuery(data *schema.ResourceData, gqlstages []gql.StageQuery, o
 		}
 		if stage.Input != nil {
 			s["input"] = stage.Input
-		} else if i == 0 {
-			s["input"] = data.Get("stage.0.input")
+		} else {
+			s["input"] = data.Get(fmt.Sprintf("stage.%d.input", i))
 		}
 		stages[i] = s
 	}

--- a/observe/resource_dataset_unit_test.go
+++ b/observe/resource_dataset_unit_test.go
@@ -1,0 +1,264 @@
+package observe
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	gql "github.com/observeinc/terraform-provider-observe/client/meta"
+)
+
+// TestFlattenAndSetQueryStageInput tests that flattenAndSetQuery correctly
+// preserves or omits the stage.input field across all cases: single-input first
+// stage, aliased-chain stages (including the redundant-input perpetual-diff bug),
+// anonymous-chain stages, and non-redundant explicit inputs.
+func TestFlattenAndSetQueryStageInput(t *testing.T) {
+	const (
+		wsOID  = "o:::workspace:41000215"
+		ds1OID = "o:::dataset:41000001"
+		ds2OID = "o:::dataset:41000002"
+		ds1ID  = "41000001"
+		ds2ID  = "41000002"
+	)
+
+	ptr := func(s string) *string { return &s }
+
+	cases := []struct {
+		name         string
+		configInputs map[string]interface{}
+		configStages []interface{}
+		gqlStages    []gql.StageQuery
+		outputStage  string
+		wantInputs   []string // expected stage[i].input in state after flattenAndSetQuery
+	}{
+		{
+			// Stage 0 with a single external input and no explicit input in
+			// config. flattenQuery omits it (defaulted from the sole input);
+			// the fallback reads config = "" → state stays "".
+			name:         "stage0_single_input_no_config_input",
+			configInputs: map[string]interface{}{"ds": ds1OID},
+			configStages: []interface{}{
+				map[string]interface{}{"pipeline": "filter true"},
+			},
+			gqlStages: []gql.StageQuery{
+				{
+					Id:       ptr("stage-0"),
+					Pipeline: "filter true",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "ds", DatasetId: ptr(ds1ID)},
+					},
+				},
+			},
+			outputStage: "stage-0",
+			wantInputs:  []string{""},
+		},
+		{
+			// Stage 0 with a single external input and an explicit input = "ds"
+			// in config. flattenQuery omits it (defaulted), but the fallback
+			// preserves the config value → state gets "ds".
+			name:         "stage0_single_input_explicit_config_input",
+			configInputs: map[string]interface{}{"ds": ds1OID},
+			configStages: []interface{}{
+				map[string]interface{}{"input": "ds", "pipeline": "filter true"},
+			},
+			gqlStages: []gql.StageQuery{
+				{
+					Id:       ptr("stage-0"),
+					Pipeline: "filter true",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "ds", DatasetId: ptr(ds1ID)},
+					},
+				},
+			},
+			outputStage: "stage-0",
+			wantInputs:  []string{"ds"},
+		},
+		{
+			// Stage 1 chains implicitly from aliased stage 0; config has no
+			// explicit input on stage 1. flattenQuery omits it (alias chain);
+			// fallback reads config = "" → state stays "".
+			name:         "aliased_chain_no_config_input",
+			configInputs: map[string]interface{}{"ds": ds1OID},
+			configStages: []interface{}{
+				map[string]interface{}{"alias": "base_stage", "pipeline": "filter true"},
+				map[string]interface{}{"pipeline": "filter false"},
+			},
+			gqlStages: []gql.StageQuery{
+				{
+					Id:       ptr("stage-0"),
+					Pipeline: "filter true",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "ds", DatasetId: ptr(ds1ID)},
+					},
+				},
+				{
+					Id:       ptr("stage-1"),
+					Pipeline: "filter false",
+					Input: []gql.StageQueryInputInputDefinition{
+						// InputName matches the alias; StageId ties it back to stage-0
+						{InputName: "base_stage", StageId: ptr("stage-0")},
+					},
+				},
+			},
+			outputStage: "stage-1",
+			wantInputs:  []string{"", ""},
+		},
+		{
+			// THE BUG FIX: stage 1 chains from aliased stage 0 but config sets
+			// input = "base_stage" explicitly (the redundant form). Before the
+			// fix, flattenAndSetQuery cleared it → state got ""; after the fix,
+			// the config value is preserved → state gets "base_stage".
+			name:         "aliased_chain_explicit_redundant_config_input",
+			configInputs: map[string]interface{}{"ds": ds1OID},
+			configStages: []interface{}{
+				map[string]interface{}{"alias": "base_stage", "pipeline": "filter true"},
+				map[string]interface{}{"input": "base_stage", "pipeline": "filter false"},
+			},
+			gqlStages: []gql.StageQuery{
+				{
+					Id:       ptr("stage-0"),
+					Pipeline: "filter true",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "ds", DatasetId: ptr(ds1ID)},
+					},
+				},
+				{
+					Id:       ptr("stage-1"),
+					Pipeline: "filter false",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "base_stage", StageId: ptr("stage-0")},
+					},
+				},
+			},
+			outputStage: "stage-1",
+			wantInputs:  []string{"", "base_stage"},
+		},
+		{
+			// Stage 1 chains from an anonymous (un-aliased) stage 0. flattenQuery
+			// omits the input (anonymous chain); fallback reads config = "" → "".
+			// Users can't reference anonymous stage IDs in config, so this can't
+			// create a perpetual diff; it's here as a no-regression guard.
+			name:         "anonymous_chain_no_config_input",
+			configInputs: map[string]interface{}{"ds": ds1OID},
+			configStages: []interface{}{
+				map[string]interface{}{"pipeline": "filter true"},
+				map[string]interface{}{"pipeline": "filter false"},
+			},
+			gqlStages: []gql.StageQuery{
+				{
+					Id:       ptr("stage-0"),
+					Pipeline: "filter true",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "ds", DatasetId: ptr(ds1ID)},
+					},
+				},
+				{
+					Id:       ptr("stage-1"),
+					Pipeline: "filter false",
+					Input: []gql.StageQueryInputInputDefinition{
+						// Anonymous chain: InputName == StageId (no user-visible alias)
+						{InputName: "stage-0", StageId: ptr("stage-0")},
+					},
+				},
+			},
+			outputStage: "stage-1",
+			wantInputs:  []string{"", ""},
+		},
+		{
+			// Stage 1 has a non-redundant explicit input pointing to a second
+			// external dataset. flattenQuery's default branch sets Input, so the
+			// fix's fallback path is never reached. No behavioral change expected.
+			name:         "non_redundant_explicit_input_to_second_dataset",
+			configInputs: map[string]interface{}{"ds1": ds1OID, "ds2": ds2OID},
+			configStages: []interface{}{
+				map[string]interface{}{"pipeline": "filter true"},
+				map[string]interface{}{"input": "ds2", "pipeline": "filter false"},
+			},
+			gqlStages: []gql.StageQuery{
+				{
+					Id:       ptr("stage-0"),
+					Pipeline: "filter true",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "ds1", DatasetId: ptr(ds1ID)},
+					},
+				},
+				{
+					Id:       ptr("stage-1"),
+					Pipeline: "filter false",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "ds2", DatasetId: ptr(ds2ID)},
+					},
+				},
+			},
+			outputStage: "stage-1",
+			wantInputs:  []string{"ds1", "ds2"},
+		},
+		{
+			// Three chained aliased stages, all with explicit redundant inputs in
+			// config. Verifies the fix applies consistently across multiple stages.
+			name:         "three_stages_all_aliased_chains_with_explicit_inputs",
+			configInputs: map[string]interface{}{"ds": ds1OID},
+			configStages: []interface{}{
+				map[string]interface{}{"alias": "s0", "pipeline": "p0"},
+				map[string]interface{}{"alias": "s1", "input": "s0", "pipeline": "p1"},
+				map[string]interface{}{"input": "s1", "pipeline": "p2"},
+			},
+			gqlStages: []gql.StageQuery{
+				{
+					Id:       ptr("stage-0"),
+					Pipeline: "p0",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "ds", DatasetId: ptr(ds1ID)},
+					},
+				},
+				{
+					Id:       ptr("stage-1"),
+					Pipeline: "p1",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "s0", StageId: ptr("stage-0")},
+					},
+				},
+				{
+					Id:       ptr("stage-2"),
+					Pipeline: "p2",
+					Input: []gql.StageQueryInputInputDefinition{
+						{InputName: "s1", StageId: ptr("stage-1")},
+					},
+				},
+			},
+			outputStage: "stage-2",
+			wantInputs:  []string{"", "s0", "s1"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			raw := map[string]interface{}{
+				"workspace": wsOID,
+				"name":      "test-dataset",
+				"inputs":    tc.configInputs,
+				"stage":     tc.configStages,
+			}
+			d := schema.TestResourceDataRaw(t, resourceDataset().Schema, raw)
+
+			if _, err := flattenAndSetQuery(d, tc.gqlStages, tc.outputStage); err != nil {
+				t.Fatalf("flattenAndSetQuery error: %v", err)
+			}
+
+			stages := d.Get("stage").([]interface{})
+			if len(stages) != len(tc.wantInputs) {
+				t.Fatalf("got %d stages, want %d", len(stages), len(tc.wantInputs))
+			}
+			for i, want := range tc.wantInputs {
+				s, ok := stages[i].(map[string]interface{})
+				if !ok {
+					t.Fatalf("stage[%d] is not a map", i)
+				}
+				got, _ := s["input"].(string)
+				if got != want {
+					t.Errorf("stage[%d].input = %q, want %q", i, got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a dataset stage's `input` field explicitly names the alias of the immediately preceding stage (a redundant but valid form), the provider produced a perpetual plan diff: every refresh cleared the value from state while the config retained it, so plans always showed `+ input = "<alias>"`.

The read path (`flattenQuery`) correctly omits the input when it's an implicit alias chain — the value is redundant and the API doesn't return it. The write-back path (`flattenAndSetQuery`) had a fallback that preserved the config's `input` when `flattenQuery` returned nil, but only for stage 0. Stages 1+ had no fallback, so their `input` was silently dropped on every read.

## Fix

Remove the `i == 0` guard in `flattenAndSetQuery` so the config-preserving fallback applies to every stage, not just the first. When `flattenQuery` omits the input (redundant chain), state now retains whatever value the user wrote in config. Users who don't set `input` on chaining stages get the same behavior as before (`data.Get` returns `""`).

## Testing

Added `TestFlattenAndSetQueryStageInput` in a new unit test file with 7 subtests covering:
- Stage 0, single input: no config input → state stays `""`; explicit config input → preserved
- Aliased chain: no config input on stage 1 → state stays `""`; explicit redundant input → now preserved (the bug)
- Anonymous chain, no config input → state stays `""`
- Non-redundant explicit input pointing to a second dataset → set by `flattenQuery`, unaffected
- Three-stage aliased chain with all redundant inputs → all preserved