### PR TITLE
fix: return null object_tags when no tags are set

### DIFF
--- a/observe/object_tags.go
+++ b/observe/object_tags.go
@@ -141,8 +141,12 @@ func entityTagsDeprecationDiags(r objectTagsReader) diag.Diagnostics {
 
 // setObjectTagsFromAPI writes tag values from the API into state and returns
 // deprecation warnings for resources using entity_tags.
+// When tags is empty, nil is written so the field is null in state rather than {}.
 func setObjectTagsFromAPI(data *schema.ResourceData, tags []gql.ObjectTagMapping) (diag.Diagnostics, error) {
-	flat := flattenObjectTagsToMap(tags)
+	var flat map[string]interface{}
+	if len(tags) > 0 {
+		flat = flattenObjectTagsToMap(tags)
+	}
 	field := activeObjectTagsField(data)
 	if field == "" {
 		field = "object_tags"


### PR DESCRIPTION
## Summary

When the API returns no object tags, `setObjectTagsFromAPI` now writes `nil` to state instead of an empty map. This lets the export flow correctly omit the field — previously, the empty map caused `object_tags = {}` to appear in exported configs even for resources with no tags set.